### PR TITLE
Potential fix for code scanning alert no. 184: Server-side request forgery

### DIFF
--- a/packages/web3-utils/ipfs-pinata.ts
+++ b/packages/web3-utils/ipfs-pinata.ts
@@ -17,6 +17,16 @@ export class IpfsPinataToolkit {
     private readonly gatewayBase = "https://gateway.pinata.cloud/ipfs"
   ) {}
 
+  private isValidCid(cid: string): boolean {
+    // Conservative validation for IPFS CIDs: non-empty, reasonable length, and safe characters only.
+    if (typeof cid !== "string") return false;
+    const trimmed = cid.trim();
+    if (!trimmed) return false;
+    if (trimmed.length < 10 || trimmed.length > 200) return false;
+    // Common CID encodings are base32/base58; restrict to alphanumeric characters for safety.
+    return /^[A-Za-z0-9]+$/.test(trimmed);
+  }
+
   async pin(content: string, name: string): Promise<PinResult> {
     const response = await fetch(`${this.baseUrl}/pinning/pinJSONToIPFS`, {
       method: "POST",
@@ -41,7 +51,11 @@ export class IpfsPinataToolkit {
   }
 
   async unpin(cid: string): Promise<void> {
-    const response = await fetch(`${this.baseUrl}/pinning/unpin/${cid}`, {
+    if (!this.isValidCid(cid)) {
+      throw new Error("Invalid CID");
+    }
+    const safeCid = encodeURIComponent(cid.trim());
+    const response = await fetch(`${this.baseUrl}/pinning/unpin/${safeCid}`, {
       method: "DELETE",
       headers: { Authorization: `Bearer ${this.jwt}` },
     });


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/184](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/184)

At a high level, we must prevent unvalidated user input from altering the structure of the outgoing HTTP request URL. Since the untrusted value here is a path segment (`.../unpin/${cid}`), the safest approach without changing behavior is to (a) validate that `cid` looks like a legitimate IPFS CID and (b) ensure it is safely encoded as a path segment (e.g., via `encodeURIComponent`). This keeps the host and base path fixed while preventing characters like `/`, `?`, `#`, or control characters from changing the meaning of the URL.

The single best fix, minimally invasive and consistent across all call sites, is to add CID validation and encoding inside `IpfsPinataToolkit.unpin` in `packages/web3-utils/ipfs-pinata.ts`, since all unpin flows go through this method. We will:

1. Add a small helper function `isValidCid(cid: string): boolean` in the same file, implementing a conservative check that:
   - `cid` is non-empty.
   - It matches typical CID character constraints (e.g., `^[A-Za-z0-9]+$` or a more restrictive base32/base58-like subset).
   - Optionally, it has reasonable length bounds to avoid abuse (e.g., 10–200 chars).
2. In `unpin(cid: string)`, check `if (!isValidCid(cid))` and throw a clear error (`Invalid CID`) before making the fetch.
3. Use `encodeURIComponent(cid)` when interpolating it into the URL path:
   - From `` `${this.baseUrl}/pinning/unpin/${cid}` `` to `` `${this.baseUrl}/pinning/unpin/${encodeURIComponent(cid)}` ``.

This preserves existing semantics for valid CIDs (which are alphanumeric and path-safe) while preventing structurally dangerous inputs and satisfying CodeQL’s SSRF taint check. No changes are needed in the callers (`simulateDeploy.ts`, `services/agent-runtime/src/index.ts`, `services/storage/src/index.ts`) because they already treat `cid` as opaque and pass it through; all security checks happen centrally at the toolkit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
