### PR TITLE
Potential fix for code scanning alert no. 180: Use of externally-controlled format string

### DIFF
--- a/apps/api-gateway/src/index.ts
+++ b/apps/api-gateway/src/index.ts
@@ -100,7 +100,7 @@ function proxyOptions(): Record<string, unknown> {
     },
     onError(err: Error, req: express.Request, res: express.Response) {
       const id = (req as RequestWithId).requestId;
-      console.error(`[gateway] proxy error path=${req.path} requestId=${id}`, err.message);
+      console.error("[gateway] proxy error path=%s requestId=%s %s", req.path, id ?? "", err.message);
       if (!res.headersSent) {
         res.status(502).json({ error: "Bad Gateway", message: "Backend unavailable. Try again or check server logs.", requestId: id ?? undefined });
       }


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/180](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/180)

In general, the way to fix this kind of issue is to ensure that untrusted data is never used as the format string (the first argument) to `console.log`, `console.error`, `util.format`, or similar functions. Instead, use a constant format string and pass untrusted values as subsequent arguments, typically interpolated with `%s` (or `%d`, etc. as appropriate). This keeps all user-controlled content confined to arguments, so any `%` in user data is treated as literal text, not as a format specifier.

For this specific case in `apps/api-gateway/src/index.ts`, we should change the `console.error` call on line 103 so that the first argument is a constant string, and `req.path` and `id` are passed as separate arguments. We must keep the log content the same, including the existing prefix and layout, and still log `err.message`. The safest way is:

```ts
console.error("[gateway] proxy error path=%s requestId=%s %s", req.path, id ?? "", err.message);
```

This preserves the message structure, avoids using a tainted value in the format string, and ensures that any `%` characters in `req.path` or `id` are treated as literal text. No new imports or dependencies are needed, and no other lines in the file require changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
