### PR TITLE
Potential fix for code scanning alert no. 191: Clear-text logging of sensitive information

### DIFF
--- a/services/orchestrator/main.py
+++ b/services/orchestrator/main.py
@@ -336,9 +336,9 @@ def _run_workflow_pipeline_job(
     """Background job: run LangGraph pipeline and persist workflow + run status."""
     set_request_id(request_id)
     logger.info(
-        "[pipeline] job start workflow_id=%s api_keys_providers=%s agent_session_jwt=%s",
+        "[pipeline] job start workflow_id=%s api_keys_count=%s agent_session_jwt=%s",
         workflow_id,
-        list(api_keys.keys()) if api_keys else [],
+        len(api_keys or {}),
         "yes" if agent_session_jwt else "no",
     )
     if request_id:

--- a/services/orchestrator/workflow.py
+++ b/services/orchestrator/workflow.py
@@ -286,9 +286,9 @@ def run_pipeline(
     import logging
 
     logging.getLogger(__name__).info(
-        "[pipeline] run_pipeline start run_id=%s api_keys_providers=%s agent_session_jwt=%s",
+        "[pipeline] run_pipeline start run_id=%s api_keys_count=%s agent_session_jwt=%s",
         run_id,
-        list(initial.get("api_keys") or {}).keys(),
+        len(initial.get("api_keys") or {}),
         "yes" if initial.get("agent_session_jwt") else "no",
     )
     config = {"configurable": {"thread_id": run_id}}


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/191](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/191)

In general, to fix clear-text logging of sensitive data, remove sensitive fields from log messages or replace them with non-sensitive aggregates (e.g., counts, booleans). When logging is still useful for observability, log derived non-sensitive metadata (like “number of providers configured”) instead of any identifiers or secret material.

For this specific code:

- In `services/orchestrator/workflow.py`, the logger call currently tries to log `api_keys` providers using `list(initial.get("api_keys") or {}).keys()`, which is both unsafe (derived from a sensitive container) and incorrect Python (calling `.keys()` on a list). We should change this to log only the number of configured providers, e.g., `len((initial.get("api_keys") or {}))`, and ensure that no secrets or provider IDs are logged.
- In `services/orchestrator/main.py`, there’s a similar pattern earlier for background jobs: `logger.info("[pipeline] job start workflow_id=%s api_keys_providers=%s agent_session_jwt=%s", workflow_id, list(api_keys.keys()) if api_keys else [], ...)`. That usage of `list(api_keys.keys())` can reveal provider identifiers derived from sensitive config and is the root of multiple variants. We should again replace it with a numeric count, e.g., `len(api_keys or {})`, which gives observability (whether keys were present) without leaking identifiers.
- The other referenced flows in `main.py` (`_build_hybrid_deploy_state`, `_resume_deploy_approval_job`, `_approve_spec_impl`, `create_run_legacy`) don’t themselves log `api_keys`; they populate state or pass it into `run_pipeline`. Once we fix the logging sites in `main.py` and `workflow.py`, all the variants will be addressed because no log line will contain data derived from `api_keys`.

Concretely:

1. In `services/orchestrator/main.py`, update the `logger.info` call in `_run_workflow_pipeline_job` to log `api_keys_count` instead of `api_keys_providers`, and remove the list of keys.
2. In `services/orchestrator/workflow.py`, fix the `logging.getLogger(__name__).info(...)` call near line 288 to:
   - Correct the `.keys()` misuse.
   - Log only `api_keys_count` (e.g., `len(initial.get("api_keys") or {})`) instead of the keys.
   - Keep the rest of the behavior unchanged (same message structure aside from field name).

No new imports are necessary; we only use `len`, which is built-in, and `logging`, which is already imported in the relevant function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
