### PR TITLE
Potential fix for code scanning alert no. 187: Clear-text logging of sensitive information

### DIFF
--- a/services/orchestrator/nodes.py
+++ b/services/orchestrator/nodes.py
@@ -155,9 +155,9 @@ async def spec_agent(state: AgentState) -> AgentState:
         try:
             api_keys = state.get("api_keys") or {}
             logger.info(
-                "[pipeline] spec_agent run_id=%s api_keys_providers=%s",
+                "[pipeline] spec_agent run_id=%s api_keys_provider_count=%s",
                 run_id,
-                list(api_keys.keys()) if api_keys else [],
+                len(api_keys) if api_keys else 0,
             )
             agent_session_jwt = state.get("agent_session_jwt") or None
             template_id_from_state = (state.get("template_id") or "").strip()


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/187](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/187)

In general, to fix clear-text logging of sensitive information, avoid logging secret values or structures derived from secret containers. Instead, log non-sensitive metadata (counts, booleans, generic placeholders) or remove the log entirely. This keeps observability while preventing leakage if logs are exposed.

For this specific case, we should stop logging `list(api_keys.keys())` and replace it with a non-sensitive summary such as the number of configured providers. This preserves the intent (debug/monitoring that some API keys are present) without revealing any identifiers tied to the secrets. No behavior of the orchestration pipeline changes; only the log message content is adjusted.

Concretely, in `services/orchestrator/nodes.py`, inside `spec_agent`, change the `logger.info` call at lines 157–161 so it no longer interpolates `api_keys`-derived data directly. A safe replacement is to log the count of providers: `api_keys_provider_count=len(api_keys)` if present, otherwise `0`. This requires only modifying that single logging call; no new imports or helper functions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
