### PR TITLE
Potential fix for code scanning alert no. 175: Uncontrolled data used in path expression

### DIFF
--- a/services/hyperagent-tools/main.py
+++ b/services/hyperagent-tools/main.py
@@ -100,9 +100,15 @@ def _compile_solcx(contract_name: str, contract_code: str) -> tuple[bool, str | 
 def _run_slither(workdir: Path, files: dict[str, str], entry: str) -> list[dict]:
     """Run Slither on contract files. Returns list of {severity, title, description, location, category}."""
     for path, content in files.items():
-        if ".." in path or path.startswith("/"):
+        # Normalize the destination path and ensure it stays within workdir
+        try:
+            dst = (workdir / path).resolve()
+        except Exception:
+            # Skip paths that cannot be resolved
             continue
-        dst = workdir / path
+        # Ensure the resolved path is contained within the temporary workdir
+        if not str(dst).startswith(str(workdir.resolve()) + os.sep):
+            continue
         dst.parent.mkdir(parents=True, exist_ok=True)
         code = content.strip()
         if "pragma solidity" not in code.lower():


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/175](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/175)

In general, the fix is to ensure that any file path derived from user input is safely constrained to a known root directory. This is normally done by joining the user path to a base directory, normalizing or resolving it, and then verifying that the resulting path is still within that base. For extra safety, you can also reject paths containing path separators or other suspicious characters, depending on your use case.

For this specific code, the best fix without changing functionality is:

- When iterating over `files.items()` in `_run_slither`, treat each `path` as a logical, relative path under the temporary `workdir`.
- Construct `dst` as `workdir / path`, then normalize it using `resolve()` (or `os.path.realpath`), and check that the resolved path is still inside `workdir`. If not, skip (or reject) that file.
- Drop the simplistic `if ".." in path or path.startswith("/")` filter, since the normalized‑path check subsumes it and is more robust (also across platforms).
- Optionally, continue to treat `path` as relative; if it starts with a separator or contains drive letters, the resolved path check will reject it.

Concretely, in `services/hyperagent-tools/main.py` inside `_run_slither`, replace the current validation and destination path handling (lines 102–106) with:

- Compute `dst = (workdir / path).resolve()`.
- If `workdir` is not a prefix of `dst` (`dst.is_relative_to(workdir)` in modern Python, or string-prefix check on `os.path.commonpath` / `str` otherwise), skip this entry.
- Then use `dst.parent.mkdir(...)` and `dst.write_text(...)` as before.

No new helper methods are strictly required; this logic can be implemented inline. We don't need additional imports beyond what is already present (`Path` from `pathlib` is already imported).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
