### PR TITLE
Potential fix for code scanning alert no. 172: Uncontrolled data used in path expression

### DIFF
--- a/services/compile/main.py
+++ b/services/compile/main.py
@@ -223,13 +223,31 @@ def _compile_hardhat_multi(workdir: Path, files: dict[str, str], entry_contract:
     return True, bytecode, data.get("abi", []), []
 
 
+def _safe_contract_name(name: str | None) -> str:
+    """
+    Normalize a user-provided contract name for safe filesystem usage.
+
+    Keeps only alphanumeric characters and underscores and strips any
+    path components. Falls back to 'Contract' if the result is empty.
+    """
+    if not name:
+        return "Contract"
+    # Strip any directory components
+    base = Path(name).name
+    # Replace unsafe characters with underscore
+    safe = re.sub(r"[^A-Za-z0-9_]", "_", base)
+    safe = safe.strip("_") or "Contract"
+    return safe
+
+
 def _compile_hardhat(workdir: Path, contract_name: str, contract_code: str) -> tuple[bool, str | None, list | None, list[str]]:
     """Compile using Hardhat (npx hardhat compile). Uses pre-built template for local node_modules."""
     contracts_dir = workdir / "contracts"
     contracts_dir.mkdir(parents=True, exist_ok=True)
     if "pragma solidity" not in contract_code.strip().lower():
         contract_code = "// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\n\n" + contract_code
-    (contracts_dir / f"{contract_name}.sol").write_text(contract_code)
+    safe_contract_name = _safe_contract_name(contract_name)
+    (contracts_dir / f"{safe_contract_name}.sol").write_text(contract_code)
     (workdir / "hardhat.config.js").write_text(
         """module.exports = { solidity: "0.8.24", paths: { sources: "./contracts" } };\n"""
     )
@@ -252,7 +270,7 @@ def _compile_hardhat(workdir: Path, contract_name: str, contract_code: str) -> t
         return False, None, None, ["Node/npx not installed or not in PATH"]
     if result.returncode != 0:
         return False, None, None, [result.stderr or result.stdout or "hardhat compile failed"]
-    artifact_path = workdir / "artifacts" / "contracts" / f"{contract_name}.sol" / f"{contract_name}.json"
+    artifact_path = workdir / "artifacts" / "contracts" / f"{safe_contract_name}.sol" / f"{safe_contract_name}.json"
     if not artifact_path.exists():
         return False, None, None, ["Artifact not found after compile"]
     data = json.loads(artifact_path.read_text())


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/172](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/172)

In general, to fix this class of issue, any user-controlled value used in a filesystem path should be validated or normalized before use. Here, the specific problem is that `contract_name` (derived from the request) is used to build `artifact_path` inside `_compile_hardhat`. We already have a helper `_safe_sol_filename` used elsewhere to sanitize file names, but that returns filenames with `.sol` included; for directory names and JSON filenames we want a “safe contract name” without extensions that can be used consistently wherever `contract_name` is used in paths.

The best fix with minimal behavioral change is:

1. Introduce a small helper `_safe_contract_name` that:
   - Accepts a `str` contract name.
   - If empty or `None`, returns a default like `"Contract"`.
   - Strips directory components (`Path(name).name`).
   - Replaces any character that is not alphanumeric or underscore with an underscore.
   - Collapses to a reasonable fallback like `"Contract"` if nothing remains.
2. Use this helper in `_compile_hardhat` to derive a safe name for filesystem paths:
   - Compute `safe_contract_name = _safe_contract_name(contract_name)`.
   - Use `safe_contract_name` instead of `contract_name` when:
     - Writing the Solidity file into `contracts_dir`: `(contracts_dir / f"{safe_contract_name}.sol")`.
     - Constructing `artifact_path`: `workdir / "artifacts" / "contracts" / f"{safe_contract_name}.sol" / f"{safe_contract_name}.json"`.
3. Keep the externally visible `contract_name` in responses and ABI extraction unchanged, so API behavior remains the same; only filesystem paths are made safe.

All of this can be done within `services/compile/main.py` without additional dependencies; we rely only on `pathlib.Path`, which is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
