### PR TITLE
Potential fix for code scanning alert no. 146: Uncontrolled command line

### DIFF
--- a/services/sandbox-docker/main.py
+++ b/services/sandbox-docker/main.py
@@ -186,10 +186,18 @@ async def sandbox_create(
     _: None = Depends(_verify_api_key),
 ) -> SandboxCreateResponse:
     """Create an ephemeral sandbox from a tarball URL. Returns preview URL."""
+    # Validate requested container port to avoid passing arbitrary values to docker.
+    try:
+        requested_port = int(body.port)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail="Invalid port: must be an integer")
+    if not (1 <= requested_port <= 65535):
+        raise HTTPException(status_code=400, detail="Invalid port: must be between 1 and 65535")
+
     sandbox_id, host_port = await _create_sandbox_container(
         body.tarball_url,
         body.timeout_minutes,
-        body.port,
+        requested_port,
     )
     meta = _sandboxes.get(sandbox_id, {})
     url = meta.get("url", f"http://localhost:{host_port}")


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/146](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/146)

In general, to fix uncontrolled command line usage you should avoid passing raw user input into command arguments. Instead, validate/normalize the input first or map it to predefined safe values. For ports, that usually means: ensure the value is an integer within a known safe range, or use an allowlist of specific container ports you support.

For this specific code, we only need to constrain `body.port` before it influences the `docker run` command. The cleanest fix, without changing existing functionality, is:

- In `sandbox_create`, before calling `_create_sandbox_container`, check that `body.port` is an integer in a reasonable TCP port range (e.g., 1–65535) and optionally in a smaller allowed subset (e.g., typical Node/HTTP ports). If validation fails, raise `HTTPException` with 400 so the request is rejected.
- Optionally, you can also enforce an explicit allowlist (e.g., `{80, 3000, 4000, 8080}`) if the service is only meant to expose typical web app ports. This strengthens guarantees and also makes the intended behavior explicit.

This only requires editing `services/sandbox-docker/main.py` at the `sandbox_create` route, inserting validation logic between reading `body` and calling `_create_sandbox_container`. No new imports are needed since `HTTPException` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
