### PR TITLE
Potential fix for code scanning alert no. 166: Uncontrolled data used in path expression

### DIFF
--- a/services/compile/main.py
+++ b/services/compile/main.py
@@ -144,6 +144,18 @@ def _compile_foundry_multi(workdir: Path, files: dict[str, str], entry_contract:
     return False, None, None, [f"Contract {entry_contract} not found in compiled output"]
 
 
+def _safe_contract_name(name: str) -> str:
+    """
+    Restrict contract names to a safe identifier format to avoid path traversal
+    when they are used in file paths.
+    """
+    name = (name or "").strip()
+    # Solidity identifiers: start with letter or underscore, then letters/digits/underscore.
+    if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", name):
+        raise ValueError("Invalid contract name")
+    return name
+
+
 def _compile_foundry_impl(workdir: Path, contract_name: str, contract_code: str) -> tuple[bool, str | None, list | None, list[str]]:
     """Compile using Foundry (forge build)."""
     src = workdir / "src"
@@ -328,9 +340,14 @@ def compile_contract(req: CompileRequest) -> CompileResponse:
         entry_contract = entry_contract or next((Path(n).stem for n in files if n.endswith(".sol")), None)
         if not entry_contract:
             raise HTTPException(status_code=400, detail="entryContract required when compiling multiple files")
-        contract_name = entry_contract
+        contract_name_raw = entry_contract
     else:
-        contract_name = entry_contract or _extract_contract_name(code or next(iter(files.values()), ""))
+        contract_name_raw = entry_contract or _extract_contract_name(code or next(iter(files.values()), ""))
+
+    try:
+        contract_name = _safe_contract_name(contract_name_raw)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid contract name")
 
     remote = _compile_via_tools(req, code or next(iter(files.values()), ""), contract_name)
     if remote is not None:


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/166](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/166)

In general, to fix this class of issue you ensure that any user-controlled data used in path expressions is first sanitized (restricted to a safe filename format) or validated against a safe root directory after normalization. For this particular case, the safest and least intrusive fix is to restrict `contract_name` to a simple, safe identifier format (e.g., Solidity identifier rules: letters, digits, underscore, starting with a letter or underscore). This preserves existing semantics (users already expect to pass contract names, not arbitrary paths) while eliminating `..`, `/`, `\`, or other dangerous characters.

Concretely, we should:

1. Introduce a helper function, for example `_safe_contract_name`, near the other small helpers (similar to `_safe_sol_filename` already used for filenames). This function will:
   - Strip whitespace from the input.
   - Validate it with a regex such as `^[A-Za-z_][A-Za-z0-9_]*$`.
   - Raise an exception (or map to a 400 response) if invalid, to maintain fail-fast behavior.
2. Use this helper in `compile_contract` at the point where `contract_name` is finalized, before it is passed down into `_compile_foundry_impl` (and indirectly into path construction). That way, any subsequent use of `contract_name` for file paths uses a sanitized version.
3. Optionally (but not strictly necessary once `contract_name` is safe), we could further harden `_compile_foundry_impl` by enforcing the same check there. However, doing it once at the API layer keeps changes minimal.

Since we can only modify the shown snippets in `services/compile/main.py`, we will:
- Add `_safe_contract_name` somewhere above `compile_contract` (for clarity, near existing helpers).
- Replace the assignment to `contract_name` around line 333 with a call to `_safe_contract_name`, handling the possibility that extraction returns `None` or an invalid name by raising an HTTP 400 error, consistent with other validations in this endpoint.
No new external dependencies are required; we can use Python’s built-in `re` (already imported).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
