### PR TITLE
Potential fix for code scanning alert no. 167: Uncontrolled data used in path expression

### DIFF
--- a/services/compile/main.py
+++ b/services/compile/main.py
@@ -146,11 +146,13 @@ def _compile_foundry_multi(workdir: Path, files: dict[str, str], entry_contract:
 
 def _compile_foundry_impl(workdir: Path, contract_name: str, contract_code: str) -> tuple[bool, str | None, list | None, list[str]]:
     """Compile using Foundry (forge build)."""
+    # Sanitize the contract name to a safe filename stem to avoid path traversal.
+    safe_contract_name = re.sub(r"[^A-Za-z0-9_]", "_", contract_name or "Contract")
     src = workdir / "src"
     src.mkdir(parents=True, exist_ok=True)
     if "pragma solidity" not in contract_code.strip().lower():
         contract_code = "// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\n\n" + contract_code
-    (src / f"{contract_name}.sol").write_text(contract_code)
+    (src / f"{safe_contract_name}.sol").write_text(contract_code)
     (workdir / "foundry.toml").write_text("[profile.default]\nsolc = \"0.8.24\"\n")
     try:
         result = subprocess.run(
@@ -164,10 +166,10 @@ def _compile_foundry_impl(workdir: Path, contract_name: str, contract_code: str)
         return False, None, None, ["Foundry (forge) not installed or not in PATH"]
     if result.returncode != 0:
         return False, None, None, [result.stderr or result.stdout or "forge build failed"]
-    out_dir = workdir / "out" / f"{contract_name}.sol"
+    out_dir = workdir / "out" / f"{safe_contract_name}.sol"
     if not out_dir.exists():
         return False, None, None, ["No output artifact; check contract name"]
-    artifact = out_dir / f"{contract_name}.json"
+    artifact = out_dir / f"{safe_contract_name}.json"
     if not artifact.exists():
         return False, None, None, ["Artifact JSON not found"]
     data = json.loads(artifact.read_text())


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/167](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/167)

In general, the problem should be fixed by ensuring that any user-controlled value used in a path expression is either (a) validated/sanitized to a safe subset of characters that cannot alter directory structure, or (b) used only after constructing and normalizing a full path and verifying it remains within an expected root directory. Here, the simplest and least invasive option is to sanitize the `contract_name` so it becomes a safe filename stem (no `/`, `\`, `..`, etc.) before it is passed to `_compile_foundry_impl`, and then use this sanitized value exclusively for path construction.

Concretely, within `_compile_foundry_impl`, introduce a local `safe_contract_name` derived from `contract_name` by applying the same `_safe_sol_filename` logic already used for user-supplied file names (or an inline equivalent, since that helper is not shown). Use `safe_contract_name` instead of `contract_name` when building any filesystem path: when creating the source file, locating the output directory, and locating the artifact JSON. This keeps external behavior compatible (the logical contract name is still `contract_name` for the API response), while preventing path traversal or injection in on-disk file operations. No changes are needed elsewhere in the file; all tainted flows go through `_compile_foundry_impl`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
