### PR TITLE
Potential fix for code scanning alert no. 169: Uncontrolled data used in path expression

### DIFF
--- a/services/compile/main.py
+++ b/services/compile/main.py
@@ -182,6 +182,21 @@ def _compile_foundry_impl(workdir: Path, contract_name: str, contract_code: str)
 _HARDHAT_TEMPLATE = Path("/opt/hardhat-template")
 
 
+def _safe_contract_name(name: str) -> str:
+    """
+    Validate a contract name used in artifact paths to avoid path traversal or
+    unexpected filesystem access. Allows only alphanumerics and underscores.
+    """
+    if not name or not isinstance(name, str):
+        raise HTTPException(status_code=400, detail="Invalid entryContract: empty or missing")
+    # Disallow path separators or dots to avoid directory traversal and extension tricks
+    if "/" in name or "\\" in name or ".." in name or "." in name:
+        raise HTTPException(status_code=400, detail="Invalid entryContract: illegal characters")
+    if not re.fullmatch(r"[A-Za-z0-9_]+", name):
+        raise HTTPException(status_code=400, detail="Invalid entryContract: only letters, digits, and '_' are allowed")
+    return name
+
+
 def _compile_hardhat_multi(workdir: Path, files: dict[str, str], entry_contract: str) -> tuple[bool, str | None, list | None, list[str]]:
     """Compile multiple interdependent files with Hardhat. Returns artifact for entry_contract."""
     contracts_dir = workdir / "contracts"
@@ -213,7 +228,8 @@ def _compile_hardhat_multi(workdir: Path, files: dict[str, str], entry_contract:
         return False, None, None, ["Node/npx not installed or not in PATH"]
     if result.returncode != 0:
         return False, None, None, [result.stderr or result.stdout or "hardhat compile failed"]
-    artifact_path = workdir / "artifacts" / "contracts" / f"{entry_contract}.sol" / f"{entry_contract}.json"
+    safe_entry_contract = _safe_contract_name(entry_contract)
+    artifact_path = workdir / "artifacts" / "contracts" / f"{safe_entry_contract}.sol" / f"{safe_entry_contract}.json"
     if not artifact_path.exists():
         return False, None, None, [f"Contract {entry_contract} not found in compiled output"]
     data = json.loads(artifact_path.read_text())


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/169](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/169)

In general, the fix is to ensure that any user-controlled string used to construct a filesystem path is validated or normalized so it cannot introduce path traversal or unexpected directories. For a simple “name-like” value such as a contract name, the safest and least disruptive approach is to restrict it to a limited character set (for example, alphanumerics, underscore, and perhaps a few other safe characters), and reject anything else with a clear error. This preserves existing behavior for normal names while blocking maliciously crafted paths.

Concretely, we should sanitize `entry_contract` before it is used inside `_compile_hardhat_multi`. We can introduce a small helper like `_safe_contract_name` that enforces a conservative pattern (for example, `^[A-Za-z0-9_]+$`), and call it at the beginning of `_compile_hardhat_multi`. That sanitized value is then used to construct `artifact_path`. We should not change the semantics of how artifacts are looked up beyond this validation, to avoid altering correct behavior.

The changes needed in `services/compile/main.py`:

1. Add a helper function `_safe_contract_name(name: str) -> str` near `_safe_sol_filename` (or near the Hardhat helpers) that:
   - Ensures `name` is non-empty.
   - Rejects any path separators or `.` segments.
   - Uses a regex (via the already-imported `re` module) to allow only a conservative set of characters.
   - Raises `HTTPException(status_code=400, ...)` if validation fails.
2. In `_compile_hardhat_multi`, before using `entry_contract` in `artifact_path`, call `_safe_contract_name` and use the result (e.g., `safe_entry = _safe_contract_name(entry_contract)`), and construct `artifact_path` with `safe_entry` instead of `entry_contract`.

No new imports are necessary since `re` and `HTTPException` are already available in this file. The only behavioral change will be that requests with invalid `entryContract` strings will now receive a 400 error instead of attempting to read a possibly dangerous path.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
