### PR TITLE
Potential fix for code scanning alert no. 170: Uncontrolled data used in path expression

### DIFF
--- a/services/compile/main.py
+++ b/services/compile/main.py
@@ -213,7 +213,9 @@ def _compile_hardhat_multi(workdir: Path, files: dict[str, str], entry_contract:
         return False, None, None, ["Node/npx not installed or not in PATH"]
     if result.returncode != 0:
         return False, None, None, [result.stderr or result.stdout or "hardhat compile failed"]
-    artifact_path = workdir / "artifacts" / "contracts" / f"{entry_contract}.sol" / f"{entry_contract}.json"
+    # Sanitize entry_contract before using it in a filesystem path
+    safe_entry_name = _safe_sol_filename(f"{entry_contract}.sol").rsplit(".sol", 1)[0]
+    artifact_path = workdir / "artifacts" / "contracts" / f"{safe_entry_name}.sol" / f"{safe_entry_name}.json"
     if not artifact_path.exists():
         return False, None, None, [f"Contract {entry_contract} not found in compiled output"]
     data = json.loads(artifact_path.read_text())


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/170](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/170)

Generally, the fix is to ensure that any user-controlled string used to construct a filesystem path is validated or normalized before use. For this endpoint, `entry_contract` should be restricted so it cannot introduce path traversal elements like `..`, `/`, or `\`, and ideally should match the Solidity contract name pattern already used elsewhere.

The best targeted fix without changing external behavior is:

1. Normalize the contract name used for artifact lookup inside `_compile_hardhat_multi` by deriving a safe version of `entry_contract` using the existing sanitization helper `_safe_sol_filename` (which is already used for other filenames).
2. Use this sanitized name (`safe_entry_name`) when building `artifact_path`, while still passing the original `entry_contract` to callers (so the API surface does not change).
3. Optionally, to be extra defensive, we can ensure the final `artifact_path` is inside `workdir` using `resolve()` and a prefix check, but the main taint-flow issue is addressed by removing the attacker's ability to inject path separators into the filename portions.

Concretely, in `services/compile/main.py`, inside `_compile_hardhat_multi`, we will:

- Introduce a new local variable `safe_entry_name = Path(entry_contract).stem` or reuse `_safe_sol_filename` to ensure no path traversal content.
- Use `safe_entry_name` instead of `entry_contract` when constructing `artifact_path` (both the `.sol` directory and `.json` filename).
- Keep the function signature and return values the same.

No new imports are required; all used classes/functions are already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
