### PR TITLE
Potential fix for code scanning alert no. 171: Uncontrolled data used in path expression

### DIFF
--- a/services/compile/main.py
+++ b/services/compile/main.py
@@ -227,9 +227,10 @@ def _compile_hardhat(workdir: Path, contract_name: str, contract_code: str) -> t
     """Compile using Hardhat (npx hardhat compile). Uses pre-built template for local node_modules."""
     contracts_dir = workdir / "contracts"
     contracts_dir.mkdir(parents=True, exist_ok=True)
+    safe_contract_name = _safe_contract_name(contract_name)
     if "pragma solidity" not in contract_code.strip().lower():
         contract_code = "// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\n\n" + contract_code
-    (contracts_dir / f"{contract_name}.sol").write_text(contract_code)
+    (contracts_dir / f"{safe_contract_name}.sol").write_text(contract_code)
     (workdir / "hardhat.config.js").write_text(
         """module.exports = { solidity: "0.8.24", paths: { sources: "./contracts" } };\n"""
     )
@@ -252,7 +253,7 @@ def _compile_hardhat(workdir: Path, contract_name: str, contract_code: str) -> t
         return False, None, None, ["Node/npx not installed or not in PATH"]
     if result.returncode != 0:
         return False, None, None, [result.stderr or result.stdout or "hardhat compile failed"]
-    artifact_path = workdir / "artifacts" / "contracts" / f"{contract_name}.sol" / f"{contract_name}.json"
+    artifact_path = workdir / "artifacts" / "contracts" / f"{safe_contract_name}.sol" / f"{safe_contract_name}.json"
     if not artifact_path.exists():
         return False, None, None, ["Artifact not found after compile"]
     data = json.loads(artifact_path.read_text())
@@ -265,6 +266,21 @@ def _compile_hardhat(workdir: Path, contract_name: str, contract_code: str) -> t
 
 def _normalize_errors(errors: list[str]) -> list[CompileErrorItem]:
     return [CompileErrorItem(message=e, sourceLocation=None) for e in errors]
+
+
+def _safe_contract_name(name: str) -> str:
+    """
+    Sanitize a user-provided contract name so it can be safely used as a filename.
+    Only allow alphanumeric characters and underscores; replace others with '_'.
+    """
+    name = (name or "").strip()
+    if not name:
+        return "Contract"
+    # Replace any disallowed character with underscore
+    safe = re.sub(r"[^A-Za-z0-9_]", "_", name)
+    # Collapse multiple underscores and strip leading/trailing ones
+    safe = re.sub(r"_+", "_", safe).strip("_")
+    return safe or "Contract"
 
 
 def _compile_via_tools(req: CompileRequest, code: str, contract_name: str) -> CompileResponse | None:


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/171](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/171)

In general, to fix uncontrolled data used in a path expression, you must ensure the user-controlled value cannot introduce path traversal or unexpected file names. Typical strategies: normalize and enforce that the resulting path stays inside a known root, or sanitize the name to an allowed character set (e.g., alphanumerics, underscore, dash), or restrict to a known set of safe names.

Here, `contract_name` is used only to name a Solidity source file (`{contract_name}.sol`) inside a temp `contracts` directory. The most compatible fix is to sanitize `contract_name` into a safe filename, similar to how `_safe_sol_filename` is already used elsewhere for `req.files`. That keeps functionality (a user-specified contract name still works, but any dangerous characters are removed or replaced) and directly addresses the taint issue.

Concretely:

- Introduce a small helper `_safe_contract_name(name: str) -> str` that:
  - Defaults to `"Contract"` if `name` is empty or only whitespace.
  - Replaces any character not matching `[A-Za-z0-9_]` with `_`.
  - Collapses repeated `_` and strips leading/trailing `_` to keep names tidy.
  - Ensures the result is not empty after sanitization (fallback to `"Contract"`).
- Use this helper in `_compile_hardhat` to create a sanitized variable (e.g., `safe_contract_name`) and use that for filesystem operations:
  - Writing the `.sol` file in the contracts directory.
  - Locating the artifact JSON (`artifacts/contracts/{name}.sol/{name}.json`), since Hardhat will base its artifact name on the filename/path, not the original unsanitized name.
- Keep `contract_name` as-is for ABI/bytecode naming in the response, so from the caller’s perspective behavior remains unchanged; only disk paths are affected.

All changes are confined to `services/compile/main.py` in the shown region: add the helper function near other helpers, and modify `_compile_hardhat` around lines 226–263 to use the safe name.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
