### PR TITLE
Potential fix for code scanning alert no. 173: Uncontrolled data used in path expression

### DIFF
--- a/services/compile/main.py
+++ b/services/compile/main.py
@@ -267,6 +267,23 @@ def _normalize_errors(errors: list[str]) -> list[CompileErrorItem]:
     return [CompileErrorItem(message=e, sourceLocation=None) for e in errors]
 
 
+def _safe_contract_name(name: str) -> str:
+    """
+    Sanitize a user-provided contract name so it is safe to use in filesystem paths.
+    Allows only alphanumeric characters, underscore and hyphen.
+    """
+    if not isinstance(name, str):
+        raise HTTPException(status_code=400, detail="Invalid contract name")
+    name = name.strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="Contract name cannot be empty")
+    # Remove any characters that are not safe for filenames
+    safe = re.sub(r"[^A-Za-z0-9_-]", "_", name)
+    if not safe:
+        raise HTTPException(status_code=400, detail="Contract name is not valid")
+    return safe
+
+
 def _compile_via_tools(req: CompileRequest, code: str, contract_name: str) -> CompileResponse | None:
     """When TOOLS_BASE_URL is set, call remote hyperagent-tools and map response."""
     if not TOOLS_BASE_URL:
@@ -331,6 +348,10 @@ def compile_contract(req: CompileRequest) -> CompileResponse:
         contract_name = entry_contract
     else:
         contract_name = entry_contract or _extract_contract_name(code or next(iter(files.values()), ""))
+
+    # Sanitize contract name before it is used in any filesystem paths or passed to compilers
+    if contract_name:
+        contract_name = _safe_contract_name(contract_name)
 
     remote = _compile_via_tools(req, code or next(iter(files.values()), ""), contract_name)
     if remote is not None:


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/173](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/173)

General approach: Ensure that any user-controlled string used to construct a filesystem path is validated or sanitized first. In this context, we want to prevent path traversal (`../`), absolute paths, or path separators in `contract_name`, and keep it as a simple, safe filename-like token.

Best fix here: Introduce a small helper (e.g. `_safe_contract_name`) that takes `contract_name` and returns a sanitized version (or raises an error) that:
- strips whitespace,
- rejects empty values,
- disallows path separators and traversal by:
  - using only a restricted character set (e.g. letters, digits, underscore, hyphen),
  - optionally replacing invalid characters with `_`, or raising an HTTP 400.

Then apply this normalizer in the single-file path before `_compile_hardhat` is called. That way, the `contract_name` used both for writing the source and reading the artifact is guaranteed safe, and no change is needed inside `_compile_hardhat` apart from relying on the already-sanitized argument. We must keep changes confined to `services/compile/main.py`, and can reuse existing imports (`re`, `HTTPException`) without adding new dependencies.

Concretely:
- Add a function `_safe_contract_name(name: str) -> str` near the other helpers (e.g. close to `_safe_sol_filename` if it exists; in the shown snippet we at least know `_safe_sol_filename` is used).
- Use `re.sub` (already imported) to allow only `[A-Za-z0-9_-]`, or similar, and strip/validate.
- In `compile_contract`, after resolving `contract_name` (line 333), sanitize it: `contract_name = _safe_contract_name(contract_name)`.
- Optionally, also sanitize `entry_contract` earlier if it’s used in other compilation paths, but for this alert, ensuring `contract_name` passed to `_compile_hardhat` is safe is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
