### PR TITLE
Potential fix for code scanning alert no. 174: Uncontrolled data used in path expression

### DIFF
--- a/services/compile/main.py
+++ b/services/compile/main.py
@@ -47,6 +47,31 @@ def _safe_sol_filename(name: str) -> str:
     return base
 
 
+def _safe_join_src(root: Path, name: str) -> Path:
+    """
+    Join a user-provided Solidity filename to a root directory safely.
+
+    Ensures the filename is valid and that the resulting path stays within the root.
+    """
+    base = _safe_sol_filename(name)
+    # Construct and resolve the full path to eliminate any symlinks or relative components.
+    full_path = (root / base).resolve()
+    try:
+        # Python 3.9+: Path.is_relative_to
+        is_inside = full_path.is_relative_to(root.resolve())
+    except AttributeError:
+        # Fallback for older Python versions
+        root_resolved = root.resolve()
+        try:
+            full_path.relative_to(root_resolved)
+            is_inside = True
+        except ValueError:
+            is_inside = False
+    if not is_inside:
+        raise HTTPException(status_code=400, detail="Resolved path escapes root directory")
+    return full_path
+
+
 class CompileRequest(BaseModel):
     contractCode: str = Field("", description="Solidity source code (optional when files provided)", alias="contractCode")
     framework: str = Field(..., description="hardhat or foundry")
@@ -362,8 +387,8 @@ def compile_contract(req: CompileRequest) -> CompileResponse:
                 src.mkdir(parents=True, exist_ok=True)
                 for name, content in req.files.items():
                     if isinstance(content, str):
-                        safe_name = _safe_sol_filename(name)
-                        (src / safe_name).write_text(content, encoding="utf-8")
+                        safe_path = _safe_join_src(src, name)
+                        safe_path.write_text(content, encoding="utf-8")
             if req.framework == "foundry":
                 success, bytecode, abi, errors = _compile_foundry_impl(workdir, contract_name, code_single)
             else:


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/174](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/174)

General fix: whenever a path is influenced by user input, construct it relative to a known safe root directory and then validate that the resolved/normalized resulting path is inside that root. Do not trust substring checks on the original input; instead, use `Path.resolve()` or `os.path.normpath` on the combined path and confirm it is still under the root.

Best fix here: keep `_safe_sol_filename` (it already enforces a strict format), but additionally introduce a helper that takes a root `Path` and a filename string, and returns a safe path by:

1. Validating the filename with `_safe_sol_filename`.
2. Joining `root / base_name`.
3. Resolving the joined path (`.resolve()`).
4. Verifying that the resolved path is within the root directory, for example via `path.is_relative_to(root)` on Python 3.9+ or an equivalent prefix check on `.resolve()` parents.
5. Returning the validated `Path`.

Then, in the loop where we currently do `(src / safe_name).write_text(...)`, we instead call this helper and write to its result. This keeps behavior the same (files still appear under `src`/`contracts` with the same names) but makes the trust boundary explicit and satisfies the static analyzer.

Concretely:

- In `services/compile/main.py`, below `_safe_sol_filename`, add a `_safe_join_src` helper (or similar) that takes `root: Path` and `name: str` and returns a validated `Path`.
- Update the block in `compile_contract` (around lines 361–366) so that inside the `for name, content in req.files.items():` loop, we compute `safe_path = _safe_join_src(src, name)` and write with `safe_path.write_text(...)` instead of `(src / safe_name)...`. We can drop the intermediate `safe_name` variable, as `_safe_join_src` calls `_safe_sol_filename` internally.
- No new imports are needed; we already import `Path` and `os`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
