### PR TITLE
Potential fix for code scanning alert no. 176: Uncontrolled data used in path expression

### DIFF
--- a/services/hyperagent-tools/main.py
+++ b/services/hyperagent-tools/main.py
@@ -100,9 +100,13 @@ def _compile_solcx(contract_name: str, contract_code: str) -> tuple[bool, str | 
 def _run_slither(workdir: Path, files: dict[str, str], entry: str) -> list[dict]:
     """Run Slither on contract files. Returns list of {severity, title, description, location, category}."""
     for path, content in files.items():
-        if ".." in path or path.startswith("/"):
+        # Normalize and ensure the destination stays within the temporary workdir
+        try:
+            dst = (workdir / path).resolve()
+            dst.relative_to(workdir)
+        except (ValueError, RuntimeError):
+            # Skip any path that escapes the workdir (path traversal, absolute paths, etc.)
             continue
-        dst = workdir / path
         dst.parent.mkdir(parents=True, exist_ok=True)
         code = content.strip()
         if "pragma solidity" not in code.lower():


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/176](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/176)

In general, to fix uncontrolled path use, normalize the composed path relative to a trusted root directory and enforce that the normalized path is contained within that root. For this code, `workdir` (the TemporaryDirectory) is the trusted root. We should reject any file key that, when joined to `workdir` and normalized, does not stay inside `workdir`. This is stronger than just checking for `".."` or leading `/`.

Concretely, in `_run_slither` we will replace the current ad‑hoc validation:

```python
for path, content in files.items():
    if ".." in path or path.startswith("/"):
        continue
    dst = workdir / path
    ...
    dst.write_text(code)
```

with logic that:

1. Constructs `dst = (workdir / path).resolve()` to normalize and eliminate `..` segments and symlinks.
2. Checks that `dst` is under `workdir` by using `dst.is_relative_to(workdir)` (Python 3.9+) or a `relative_to` try/except fallback.
3. Skips any file whose resolved path is outside `workdir`.
4. Then proceeds to create parent directories and write the file as before.

We already import `Path` and `tempfile`, so no new imports are needed. The changes are confined to the loop in `_run_slither` in `services/hyperagent-tools/main.py`, around lines 100–110. Existing functionality (writing the same content, prepending SPDX/pragma, running Slither) remains unchanged; only path validation is hardened.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
