### PR TITLE
Potential fix for code scanning alert no. 177: Uncontrolled data used in path expression

### DIFF
--- a/services/audit/main.py
+++ b/services/audit/main.py
@@ -73,7 +73,13 @@ def _run_slither_impl(workdir: Path, contract_name: str, code: str, detectors: s
     src.mkdir(parents=True, exist_ok=True)
     if "pragma solidity" not in code.strip().lower():
         code = "// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\n\n" + code
-    (src / f"{contract_name}.sol").write_text(code)
+    sol_path = src / f"{contract_name}.sol"
+    # Normalize and ensure the file path stays within the expected source directory
+    src_root = src.resolve()
+    sol_path_resolved = sol_path.resolve()
+    if os.path.commonpath([str(src_root), str(sol_path_resolved)]) != str(src_root):
+        raise HTTPException(status_code=400, detail="Invalid contract name path")
+    sol_path.write_text(code)
     (workdir / "foundry.toml").write_text('[profile.default]\nsolc = "0.8.24"\n')
     cmd = ["slither", str(src), "--json", "-"]
     if detectors:


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/177](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/177)

In general, to fix this class of issue you ensure that any path derived from user input is both (a) reduced to an allowed form (for example, a simple filename or a whitelisted pattern) and (b) used only after constructing and normalizing the full filesystem path and verifying that it remains under a trusted base directory. This typically means using `os.path.normpath` or `Path.resolve()` on `base_dir / user_component` and then checking that the result is still inside `base_dir`.

For this code, the best minimally invasive fix is to add a safety check in `_run_slither_impl` right before writing the file. We already have a trusted base directory (`src = workdir / "src"`) and a sanitized `contract_name`. We will:

1. Construct the path as before: `candidate = src / f"{contract_name}.sol"`.
2. Resolve it: `fullpath = candidate.resolve()`.
3. Resolve the base directory: `src_root = src.resolve()`.
4. Verify that `fullpath` is within `src_root`. In Python 3.9+ we can use `fullpath.is_relative_to(src_root)`; to stay compatible across versions, we can instead compare `src_root` to the beginning of `fullpath.parents` or use `os.path.commonpath`. Since we already import `os`, we’ll use `os.path.commonpath`.
5. If the check fails, raise an `HTTPException` with a 400 status.

Only `_run_slither_impl` needs to change; all audit endpoints eventually reach this function (including the exploit variant), so a single check there will address all alert variants. We’ll keep `_safe_contract_name` as is, since it is still useful; the new path-based check is an additional defense-in-depth layer and should not change behavior for valid inputs.

Concretely, in `services/audit/main.py` around line 71–77, we will replace the single write call

```py
(src / f"{contract_name}.sol").write_text(code)
```

with a few lines that build `sol_path`, resolve and check it against `src`, and then write to `sol_path` only if it’s safe.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
