### PR TITLE
Potential fix for code scanning alert no. 188: Clear-text logging of sensitive information

### DIFF
--- a/services/orchestrator/nodes.py
+++ b/services/orchestrator/nodes.py
@@ -244,9 +244,9 @@ async def design_agent(state: AgentState) -> AgentState:
             api_keys = state.get("api_keys") or {}
             agent_session_jwt = state.get("agent_session_jwt") or None
             logger.info(
-                "[pipeline] design_agent run_id=%s api_keys_providers=%s agent_session_jwt=%s",
+                "[pipeline] design_agent run_id=%s has_api_keys=%s agent_session_jwt=%s",
                 run_id,
-                list(api_keys.keys()) if api_keys else [],
+                "yes" if api_keys else "no",
                 "yes" if agent_session_jwt else "no",
             )
             target_chains = spec.get("chains", [])


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/188](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/188)

In general, sensitive material (credentials, tokens, API keys, secrets) or data derived from them should not be written to logs, even if it appears only in part or obfuscated form, unless there is a strong, well-documented reason. Instead, log high-level metadata that preserves observability (e.g., whether credentials are configured) without exposing identifiers or values.

For this specific case, the best fix is to stop logging the list of API key providers derived from the `api_keys` mapping and instead log only a boolean or count, while preserving the rest of the log line’s behavior. That means changing the `logger.info` call in `design_agent` so it no longer includes `list(api_keys.keys()) if api_keys else []`. A minimal, backwards-compatible change is to replace that argument with either `bool(api_keys)` or `len(api_keys)`. Given the existing `agent_session_jwt` handling logs “yes/no”, a consistent choice is to log whether any API keys are present, e.g., `"yes"`/`"no"` or a count. We will update the format string and argument list accordingly, without modifying other behavior in `design_agent` or elsewhere. No additional imports or helper functions are needed, and changes are confined to `services/orchestrator/nodes.py` around the `logger.info` call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
