### PR TITLE
Potential fix for code scanning alert no. 189: Clear-text logging of sensitive information

### DIFF
--- a/services/orchestrator/main.py
+++ b/services/orchestrator/main.py
@@ -336,9 +336,9 @@ def _run_workflow_pipeline_job(
     """Background job: run LangGraph pipeline and persist workflow + run status."""
     set_request_id(request_id)
     logger.info(
-        "[pipeline] job start workflow_id=%s api_keys_providers=%s agent_session_jwt=%s",
+        "[pipeline] job start workflow_id=%s api_keys_present=%s agent_session_jwt=%s",
         workflow_id,
-        list(api_keys.keys()) if api_keys else [],
+        "yes" if api_keys else "no",
         "yes" if agent_session_jwt else "no",
     )
     if request_id:


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/189](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/189)

In general, to fix clear-text logging of sensitive information, remove sensitive fields from log messages, or replace them with non-sensitive indicators (e.g., booleans, counts) that preserve observability without exposing secrets. Never log raw secrets, tokens, passwords, or detailed structures that encode credentials.

For this specific case, the problematic part is logging `api_keys_providers=%s` with `list(api_keys.keys()) if api_keys else []`. The safest change that preserves operational value is to log only whether any BYOK/API keys are present, not which ones. For example, we can log `api_keys_present=yes/no` or `api_keys_count=n`. This avoids any tainted data flowing into the log while keeping the existing workflow logic intact. We only need to adjust the log message and parameter list inside `_run_workflow_pipeline_job` in `services/orchestrator/main.py`; no extra imports or helper methods are required.

Concretely:
- Change the format string at line 339 to remove `api_keys_providers=%s` and replace it with a non-sensitive indicator such as `api_keys_present=%s`.
- Change the corresponding argument at line 341 from `list(api_keys.keys()) if api_keys else []` to a boolean/yes-no string like `"yes" if api_keys else "no"` or a count like `len(api_keys) if api_keys else 0`.
- Leave all other workflow logic unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
