### PR TITLE
Potential fix for code scanning alert no. 190: Clear-text logging of sensitive information

### DIFF
--- a/services/orchestrator/main.py
+++ b/services/orchestrator/main.py
@@ -605,10 +605,13 @@ def workflows_generate(
     request_id = (
         request.headers.get("x-request-id") or request.headers.get("X-Request-Id") or ""
     ).strip() or None
+    api_keys_present = bool(api_keys)
+    api_keys_provider_count = len(api_keys) if api_keys else 0
     logger.info(
-        "[generate] pipeline job queued workflow_id=%s api_keys_providers=%s agent_session_jwt=%s",
+        "[generate] pipeline job queued workflow_id=%s api_keys_present=%s api_keys_provider_count=%s agent_session_jwt=%s",
         workflow_id,
-        list(api_keys.keys()) if api_keys else [],
+        api_keys_present,
+        api_keys_provider_count,
         "yes" if agent_session_jwt else "no",
     )
     background_tasks.add_task(


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/190](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/190)

Generally, the fix is to avoid logging any data derived from `body.api_keys` / `api_keys` (or other credential containers). Instead, log only high-level booleans or counts that convey necessary operational information without exposing credential structure.

For this specific code:

- The problematic log call is:

  ```python
  logger.info(
      "[generate] pipeline job queued workflow_id=%s api_keys_providers=%s agent_session_jwt=%s",
      workflow_id,
      list(api_keys.keys()) if api_keys else [],
      "yes" if agent_session_jwt else "no",
  )
  ```

- We can preserve functionality (observability) by logging whether any API keys were present, or the count of providers, rather than listing the provider identifiers themselves. For example:

  ```python
  api_keys_present = bool(api_keys)
  api_keys_provider_count = len(api_keys) if api_keys else 0
  logger.info(
      "[generate] pipeline job queued workflow_id=%s api_keys_present=%s api_keys_provider_count=%s agent_session_jwt=%s",
      workflow_id,
      api_keys_present,
      api_keys_provider_count,
      "yes" if agent_session_jwt else "no",
  )
  ```

- This removes the direct use of `api_keys.keys()` in the log message, breaking the taint flow from `body.api_keys` to the logging sink while still giving developers enough information.

- No new imports or helper methods are needed; the change is localized to the `logger.info` call in `services/orchestrator/main.py` around line 609–613.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
