### PR TITLE
Potential fix for code scanning alert no. 150: Clear-text logging of sensitive information

### DIFF
--- a/services/orchestrator/main.py
+++ b/services/orchestrator/main.py
@@ -563,11 +563,12 @@ def workflows_generate(
             )
     api_keys = body.api_keys or _get_keys_for_run(user_id, DEFAULT_WORKSPACE)
     logger.info(
-        "[generate] user_id=%s body_keys=%s supabase_keys=%s resolved=%s",
+        "[generate] user_id=%s body_has_keys=%s body_key_count=%s supabase_keys=%s resolved_key_count=%s",
         user_id,
-        list(body.api_keys.keys()) if body.api_keys else "none",
+        bool(body.api_keys),
+        len(body.api_keys) if body.api_keys else 0,
         "yes" if (not body.api_keys and api_keys) else "skipped",
-        list(api_keys.keys()) if api_keys else "empty",
+        len(api_keys) if api_keys else 0,
     )
     if not api_keys:
         raise HTTPException(


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/150](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/150)

In general, to fix clear-text logging of sensitive information, remove or redact any logs that include secrets or potentially sensitive user data, and replace them with non-sensitive metadata (counts, booleans, high-level statuses). For API keys, log “has keys: yes/no” or counts instead of key names/values.

For this specific case in `services/orchestrator/main.py`, we should change the `logger.info` call so that it no longer logs `body_keys` as the list of keys, nor the exact list of `resolved` keys. Instead, we can log: whether any keys were provided in the body, the count of such keys, whether supabase (or other backing store) was used, and how many keys ended up in `api_keys`. This keeps the intended diagnostics (“did keys come from body or from supabase, and how many?”) without leaking any identifiers.

Concretely:
- Edit the block around lines 564–571.
- Replace the existing `logger.info` message with something like:
  - `"[generate] user_id=%s body_has_keys=%s body_key_count=%s supabase_keys=%s resolved_key_count=%s"`
  - with arguments computing booleans/counts instead of listing names.
- No new imports or helper functions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
