### PR TITLE
Potential fix for code scanning alert no. 151: Clear-text logging of sensitive information

### DIFF
--- a/services/orchestrator/main.py
+++ b/services/orchestrator/main.py
@@ -562,12 +562,15 @@ def workflows_generate(
                 detail="Failed to deduct credits. Top up and try again.",
             )
     api_keys = body.api_keys or _get_keys_for_run(user_id, DEFAULT_WORKSPACE)
+    body_keys_present = bool(body.api_keys)
+    supabase_keys_used = bool(not body.api_keys and api_keys)
+    resolved_has_keys = bool(api_keys)
     logger.info(
-        "[generate] user_id=%s body_keys=%s supabase_keys=%s resolved=%s",
+        "[generate] user_id=%s body_keys_present=%s supabase_keys_used=%s resolved_has_keys=%s",
         user_id,
-        list(body.api_keys.keys()) if body.api_keys else "none",
-        "yes" if (not body.api_keys and api_keys) else "skipped",
-        list(api_keys.keys()) if api_keys else "empty",
+        body_keys_present,
+        supabase_keys_used,
+        resolved_has_keys,
     )
     if not api_keys:
         raise HTTPException(


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/151](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/151)

In general, the fix is to avoid logging any information derived from `api_keys` that might reveal details about configured secrets. Instead of logging the key names (and implicitly, how many there are), log only coarse, non-sensitive indicators such as whether the request contained keys, whether Supabase-provided keys were used, and whether any keys were successfully resolved.

Concretely, in `services/orchestrator/main.py` around lines 564–571, we will modify the `logger.info` call so it no longer includes `list(body.api_keys.keys())` or `list(api_keys.keys())`. We will replace those with boolean or simple string flags, for example:

- `body_keys_present = bool(body.api_keys)` – whether the request provided any keys at all.
- `supabase_keys_used = bool(not body.api_keys and api_keys)` – whether fallback keys were obtained from Supabase.
- `resolved_has_keys = bool(api_keys)` – whether any keys were resolved in the end.

Then log these non-sensitive values instead of the specific key names or lists. No new imports are needed, and existing functionality is preserved: the behavior of `api_keys` resolution and subsequent logic is unchanged; we only reduce log detail to avoid leaking sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
