### PR TITLE
Potential fix for code scanning alert no. 161: Uncontrolled data used in path expression

### DIFF
--- a/services/compile/main.py
+++ b/services/compile/main.py
@@ -111,6 +111,19 @@ def _compile_solcx(contract_name: str, contract_code: str) -> tuple[bool, str | 
     return False, None, None, ["Contract not found in compiled output"]
 
 
+def _safe_artifact_stem(name: str) -> str:
+    """
+    Derive a safe artifact base name from a potentially untrusted file name.
+
+    Keeps only alphanumeric characters, underscore and dash, replacing any
+    other character with an underscore. Falls back to "contract" if empty.
+    """
+    stem = Path(name).stem
+    # Replace any character that is not alphanumeric, underscore or dash.
+    safe_stem = re.sub(r"[^A-Za-z0-9_-]", "_", stem)
+    return safe_stem or "contract"
+
+
 def _compile_foundry_multi(workdir: Path, files: dict[str, str], entry_contract: str) -> tuple[bool, str | None, list | None, list[str]]:
     """Compile multiple interdependent files with Foundry. Returns artifact for entry_contract."""
     src = workdir / "src"
@@ -130,7 +143,7 @@ def _compile_foundry_multi(workdir: Path, files: dict[str, str], entry_contract:
     if result.returncode != 0:
         return False, None, None, [result.stderr or result.stdout or "forge build failed"]
     for name in files:
-        base = Path(name).stem
+        base = _safe_artifact_stem(name)
         out_dir = workdir / "out" / f"{base}.sol"
         if out_dir.exists():
             artifact = out_dir / f"{base}.json"


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/161](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/161)

In general, the fix is to ensure that any path derived from user input is validated or sanitized before being used, and to guarantee that the resulting path remains within a designated safe root. Techniques include using `os.path.normpath`/`Path.resolve()` and confirming the normalized path is under a trusted directory, or restricting filenames to a safe character set / pattern.

For this specific case, the dangerous value is the `base` derived from `Path(name).stem`, where `name` comes from `files` provided in the request. The safest way to fix this without changing existing behavior is:

1. Normalize and sanitize `base` into a safe, filesystem-friendly identifier (e.g., allow only letters, digits, underscore, and optionally `-`).
2. Ensure the resulting path is constructed relative to `workdir / "out"` and that no path traversal is possible (even if future code changes the construction).
3. Use that sanitized `base` when building `out_dir` and `artifact`.

We can implement a small helper `_safe_artifact_stem` alongside `_safe_sol_filename`, which:

- Takes the raw `name` from `files`.
- Extracts a stem via `Path(name).stem`.
- Applies a regex to drop unsafe characters, mapping anything not `[A-Za-z0-9_-]` to `_`.
- Falls back to a default like `"contract"` if everything is stripped.

Then, in `_compile_foundry_multi`, replace `base = Path(name).stem` with `base = _safe_artifact_stem(name)`. This ensures that `out_dir` and `artifact` are built using a sanitized, non-dangerous base name, mitigating the uncontrolled path issue but preserving logical behavior (artifacts still named after the contract’s filename, just cleaned).

All changes remain within `services/compile/main.py`. We only need to:

- Add `_safe_artifact_stem` near the other helper functions (e.g., close to `_safe_sol_filename`).
- Update the `base = Path(name).stem` line to use the new helper.
- No new external dependencies are required; we already import `re` and `Path`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
