### PR TITLE
Potential fix for code scanning alert no. 163: Uncontrolled data used in path expression

### DIFF
--- a/services/compile/main.py
+++ b/services/compile/main.py
@@ -130,7 +130,10 @@ def _compile_foundry_multi(workdir: Path, files: dict[str, str], entry_contract:
     if result.returncode != 0:
         return False, None, None, [result.stderr or result.stdout or "forge build failed"]
     for name in files:
-        base = Path(name).stem
+        # Use the same safe filename logic as when writing sources, to avoid
+        # uncontrolled paths derived from untrusted `name` and to match Foundry's output.
+        safe_name = _safe_sol_filename(name)
+        base = Path(safe_name).stem
         out_dir = workdir / "out" / f"{base}.sol"
         if out_dir.exists():
             artifact = out_dir / f"{base}.json"


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/163](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/163)

In general, to fix uncontrolled-path issues you either (1) sanitize the untrusted path components before using them, or (2) enforce that the final computed path stays within an expected root (using normalization and prefix checks). Here, the simplest way without changing functionality is to ensure the `base` used for artifact lookup is derived via the same safe filename logic used when writing the source files, instead of directly from the untrusted `name`. That way, any problematic characters are normalized away and we maintain a consistent mapping between input names, source files, and expected artifact names.

Concretely, we should change the loop in `_compile_foundry_multi` where `base` is computed from `Path(name).stem`. When writing the source files above, we already use `_safe_sol_filename(name)` into `safe`, then write to `src / safe`. Foundry will name its output directories and JSON artifacts based on those safe filenames, not the original `name`. Therefore, in the later loop, we should recompute `safe = _safe_sol_filename(name)` and then derive `base = Path(safe).stem`. This keeps `base` consistent with the filenames Foundry actually sees and also ensures `base` goes through the safe-normalization function. Then `out_dir` and `artifact` become fully controlled paths under `workdir / "out"` with sanitized names. We do not need any new imports or helper methods; `_safe_sol_filename` already exists in this file (and is already used earlier in `_compile_foundry_multi`), so we just reuse it. No other behavior changes: compilation still finds the same artifact because Foundry outputs are keyed by the sanitized filenames.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
