### PR TITLE
Potential fix for code scanning alert no. 164: Uncontrolled data used in path expression

### DIFF
--- a/services/compile/main.py
+++ b/services/compile/main.py
@@ -144,13 +144,28 @@ def _compile_foundry_multi(workdir: Path, files: dict[str, str], entry_contract:
     return False, None, None, [f"Contract {entry_contract} not found in compiled output"]
 
 
+def _safe_single_contract_name(name: str) -> str:
+    """
+    Sanitize a single contract name for use as a Solidity source filename.
+    Restricts to a safe subset of characters to avoid path traversal or
+    directory manipulation when writing files.
+    """
+    # Take only the final path component in case any separators are present.
+    base = os.path.basename(name)
+    # Allow only alphanumeric characters and underscore; replace others with '_'.
+    safe = re.sub(r"[^0-9A-Za-z_]", "_", base)
+    # Ensure we have a non-empty filename.
+    return safe or "Contract"
+
+
 def _compile_foundry_impl(workdir: Path, contract_name: str, contract_code: str) -> tuple[bool, str | None, list | None, list[str]]:
     """Compile using Foundry (forge build)."""
     src = workdir / "src"
     src.mkdir(parents=True, exist_ok=True)
     if "pragma solidity" not in contract_code.strip().lower():
         contract_code = "// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\n\n" + contract_code
-    (src / f"{contract_name}.sol").write_text(contract_code)
+    safe_contract_name = _safe_single_contract_name(contract_name)
+    (src / f"{safe_contract_name}.sol").write_text(contract_code)
     (workdir / "foundry.toml").write_text("[profile.default]\nsolc = \"0.8.24\"\n")
     try:
         result = subprocess.run(


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/164](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/164)

In general, to fix uncontrolled path usage you should validate or sanitize any user-controlled string before using it to construct filesystem paths. For this case, the minimal, behavior-preserving fix is to derive a safe filename from `contract_name` inside `_compile_foundry_impl`, in the same spirit as `_safe_sol_filename` is used when writing user-provided files for multi-file compilation. The sanitization should (1) strip directory components, (2) remove or replace any characters that are not safe in filenames, and (3) fall back to a benign default if the result is empty.

Concretely, in `services/compile/main.py` within `_compile_foundry_impl`, instead of writing directly to `(src / f"{contract_name}.sol")`, we introduce a local `safe_contract_name` that is computed by a small helper `_safe_single_contract_name`. That helper can live near the other utility helpers (or just above `_compile_foundry_impl`) and will enforce a restricted character set (for example, Solidity identifier characters `[A-Za-z0-9_]`), replace anything else with `_`, and ensure the name is not empty. We then write to `src / f"{safe_contract_name}.sol"`. This keeps the externally visible interface identical (the contract is still compiled under the original `contract_name` we pass to Foundry), but ensures the actual filesystem path is not influenced by path traversal characters. No new third-party dependencies are required; the standard library `re` and `os.path` already imported are sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
