### PR TITLE
Potential fix for code scanning alert no. 165: Uncontrolled data used in path expression

### DIFF
--- a/services/compile/main.py
+++ b/services/compile/main.py
@@ -144,8 +144,30 @@ def _compile_foundry_multi(workdir: Path, files: dict[str, str], entry_contract:
     return False, None, None, [f"Contract {entry_contract} not found in compiled output"]
 
 
+def _safe_contract_name(name: str) -> str:
+    """
+    Sanitize a user-provided contract name so it cannot influence directory structure.
+
+    Allows only Solidity-identifier-style names: letters, digits, and underscore,
+    and forbids path separators or traversal tokens.
+    """
+    if name is None:
+        raise ValueError("contract name is required")
+    name = name.strip()
+    if not name:
+        raise ValueError("contract name must not be empty")
+    # Disallow obvious path-manipulation patterns
+    if "/" in name or "\\" in name or ".." in name or name.startswith("."):
+        raise ValueError("invalid contract name")
+    # Restrict to a conservative pattern: starts with letter or underscore, then letters/digits/underscore
+    if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", name):
+        raise ValueError("invalid contract name")
+    return name
+
+
 def _compile_foundry_impl(workdir: Path, contract_name: str, contract_code: str) -> tuple[bool, str | None, list | None, list[str]]:
     """Compile using Foundry (forge build)."""
+    contract_name = _safe_contract_name(contract_name)
     src = workdir / "src"
     src.mkdir(parents=True, exist_ok=True)
     if "pragma solidity" not in contract_code.strip().lower():
@@ -331,6 +353,11 @@ def compile_contract(req: CompileRequest) -> CompileResponse:
         contract_name = entry_contract
     else:
         contract_name = entry_contract or _extract_contract_name(code or next(iter(files.values()), ""))
+
+    try:
+        contract_name = _safe_contract_name(contract_name)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
 
     remote = _compile_via_tools(req, code or next(iter(files.values()), ""), contract_name)
     if remote is not None:


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/165](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/165)

In general, to fix uncontrolled path usage, you must prevent untrusted input from influencing directory structure or file path components. For this case, we should normalize and strictly validate `contract_name` before using it to form paths, allowing only safe characters and disallowing path separators, `..`, or leading dots. Then use this sanitized value consistently wherever `contract_name` is used in filesystem operations.

The best low-impact fix here is:

- Introduce a helper function (e.g. `_safe_contract_name`) that:
  - Accepts a string (possibly `None`).
  - Strips whitespace.
  - Rejects empty strings, strings containing `/` or `\`, `..`, or starting with `.`.
  - Enforces a conservative pattern (e.g. Solidity identifier-like: letters, digits, underscore).
  - On violation, raises a clear `ValueError`.
- In `compile_contract`, once `contract_name` has been determined (after lines 331–333), but before any compilation or temp-dir work, pass it through `_safe_contract_name`. If invalid, translate the `ValueError` into a `HTTPException(400, ...)` so the API behavior is well-defined.
- In `_compile_foundry_impl`, we don’t need additional sanitization if we guarantee all callers sanitize before calling, but adding a local defensive call to `_safe_contract_name` is cheap and makes the function safe if used elsewhere in the future.
- Use the sanitized value (same variable) for both source and output paths, so existing behavior for valid names stays the same and Foundry’s expectations about file and directory names remain intact.

No new external libraries are needed; a simple regex or manual checks are sufficient and keep the change localized within `services/compile/main.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
