### PR TITLE
apps/studio: SessionProvider, bootstrap failure fatal, SSE-first workflow updates

### DIFF
--- a/apps/studio/components/providers/ClientProviders.tsx
+++ b/apps/studio/components/providers/ClientProviders.tsx
@@ -6,6 +6,7 @@ import { LayoutProvider } from '@/components/providers/LayoutProvider';
 import { NetworksProvider } from '@/components/providers/NetworksProvider';
 import { SelectedNetworkProvider } from '@/components/providers/SelectedNetworkProvider';
 import { PipelineStateProvider } from '@/components/providers/PipelineStateProvider';
+import { SessionProvider } from '@/components/providers/SessionProvider';
 import { ThirdwebProviderWrapper } from '@/components/providers/ThirdwebProviderWrapper';
 import { WalletAuthProvider } from '@/components/providers/WalletAuthContext';
 import { LayoutSwitcher } from '@/components/layout/LayoutSwitcher';
@@ -15,6 +16,7 @@ import { Analytics } from '@vercel/analytics/next';
 /**
  * Single client boundary for all providers. Ensures ThirdwebProvider wraps
  * the entire app so useActiveAccount and other thirdweb hooks work everywhere.
+ * SessionProvider is the single source of truth for isAuthenticated.
  * WalletAuthProvider exposes sign-in via context so components in portals (e.g. Dialog)
  * can sign in without calling thirdweb hooks directly.
  */
@@ -22,6 +24,7 @@ export function ClientProviders({ children }: { children: React.ReactNode }) {
   return (
     <ThirdwebProviderWrapper>
       <WalletAuthProvider>
+      <SessionProvider>
       <ConfigProvider>
         <ApiAuthProvider>
           <NetworksProvider>
@@ -37,6 +40,7 @@ export function ClientProviders({ children }: { children: React.ReactNode }) {
           <Analytics />
         </ApiAuthProvider>
       </ConfigProvider>
+      </SessionProvider>
       </WalletAuthProvider>
     </ThirdwebProviderWrapper>
   );

--- a/apps/studio/components/providers/SessionProvider.tsx
+++ b/apps/studio/components/providers/SessionProvider.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { getStoredSession, SESSION_CHANGE_EVENT } from '@/lib/session-store';
+
+export interface SessionContextValue {
+  isAuthenticated: boolean;
+  session: { access_token: string; expires_at: number } | null;
+  refetch: () => void;
+}
+
+export const SessionContext = createContext<SessionContextValue | null>(null);
+
+/**
+ * Single source of truth for session state. Combines localStorage, cookie, and in-memory React state.
+ * All pages and hooks should use useSession() for isAuthenticated instead of their own logic.
+ * 401 handling and redirect remain in ApiAuthProvider.
+ */
+export function SessionProvider({ children }: { children: React.ReactNode }) {
+  const [session, setSession] = useState<{ access_token: string; expires_at: number } | null>(null);
+
+  const refetch = useCallback(() => {
+    setSession(getStoredSession());
+  }, []);
+
+  useEffect(() => {
+    refetch();
+    const onChange = () => refetch();
+    window.addEventListener(SESSION_CHANGE_EVENT, onChange);
+    return () => window.removeEventListener(SESSION_CHANGE_EVENT, onChange);
+  }, [refetch]);
+
+  const value: SessionContextValue = {
+    isAuthenticated: !!session?.access_token,
+    session,
+    refetch,
+  };
+
+  return (
+    <SessionContext.Provider value={value}>
+      {children}
+    </SessionContext.Provider>
+  );
+}
+
+export function useSession(): SessionContextValue {
+  const ctx = useContext(SessionContext);
+  if (!ctx) {
+    throw new Error('useSession must be used within SessionProvider');
+  }
+  return ctx;
+}

--- a/apps/studio/hooks/useAutoBootstrap.ts
+++ b/apps/studio/hooks/useAutoBootstrap.ts
@@ -1,18 +1,22 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
 import { useActiveAccount } from 'thirdweb/react';
 import { useSignInWithWallet } from '@/hooks/useSignInWithWallet';
 import { getStoredSession } from '@/lib/session-store';
+import { ROUTES } from '@/constants/routes';
 
 /**
  * ZSPS: Proactive session bootstrap.
  * When AutoConnect restores wallet but no valid session exists, triggers bootstrap
  * so wallet_users is updated and a fresh JWT is issued.
+ * On failure, redirects to login to avoid ghost state (wallet connected, no session).
  */
 export function useAutoBootstrap(): void {
   const account = useActiveAccount();
   const { signIn } = useSignInWithWallet();
+  const router = useRouter();
   const bootstrappingRef = useRef(false);
 
   useEffect(() => {
@@ -23,8 +27,14 @@ export function useAutoBootstrap(): void {
 
     bootstrappingRef.current = true;
     signIn()
+      .then((ok) => {
+        if (!ok) router.replace(ROUTES.LOGIN);
+      })
+      .catch(() => {
+        router.replace(ROUTES.LOGIN);
+      })
       .finally(() => {
         bootstrappingRef.current = false;
       });
-  }, [account?.address, signIn]);
+  }, [account?.address, signIn, router]);
 }

--- a/apps/studio/hooks/useSession.ts
+++ b/apps/studio/hooks/useSession.ts
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useContext, useState, useEffect } from "react";
 import { getStoredSession, SESSION_CHANGE_EVENT } from "@/lib/session-store";
+import { SessionContext } from "@/components/providers/SessionProvider";
 
 export interface UseSessionReturn {
   hasSession: boolean;
@@ -9,11 +10,15 @@ export interface UseSessionReturn {
 }
 
 /**
- * Single source of truth for API session (JWT in session store).
- * isReady is false until after mount so server and first client render match (no hydration mismatch).
- * Subscribes to session change events so sign-in/sign-out updates all consumers.
+ * Single source of truth for API session. Uses SessionProvider context when available.
+ * Falls back to direct session-store read when outside SessionProvider (e.g. login page).
  */
 export function useSession(): UseSessionReturn {
+  const ctx = useContext(SessionContext);
+  if (ctx) {
+    return { hasSession: ctx.isAuthenticated, isReady: true };
+  }
+
   const [hasSession, setHasSession] = useState(false);
   const [isReady, setIsReady] = useState(false);
 


### PR DESCRIPTION
# Pull Request

---

## Title / Naming convention

**apps/studio: SessionProvider, bootstrap failure fatal, SSE-first workflow updates**

---

## Context / Description

**What** does this PR change, and **why**?

- Makes SessionProvider the single source of truth for session state across protected pages.
- Makes `useAutoBootstrap` treat bootstrap failure as fatal: blocking error, redirect to /login, no ghost state.
- Upgrades middleware from cookie-only gating to session-expiry-aware validation.
- Makes SSE the primary workflow-progress path; keeps polling only as fallback when stream fails or goes stale.
- Splits `apps/studio/lib/api.ts` by domain (core, workflows, billing, settings, deployments).
- Removes fake arrays, fake histories, zero-value placeholders; labels unfinished surfaces explicitly.

---

## Related issues / tickets

- **Related** Full-completion implementation outline (Workstream 3: Auth/session correctness, Workstream 6: Frontend/runtime UX)
- **Related** docs/internal/boundaries.md

---

## Type of change

- [x] **Feature** (session authority, SSE-first)
- [x] **Bug fix** (ghost state, bootstrap failure)
- [x] **Refactor** (api.ts split)

---

## How to test

1. Open /payments or another protected route without session; confirm redirect
2. Force bootstrap failure; confirm UI never lands in "connected wallet but no session" state
3. Start a workflow; confirm progress is primarily stream-driven, polling only when stream disconnected

**Special setup / config:** AUTH_JWT_SECRET, SUPABASE_URL, SUPABASE_SERVICE_KEY

---

## Author checklist (before requesting review)

- [x] Code follows the project's style guidelines
- [ ] Unit tests added or updated
- [x] Documentation updated
- [x] Changes tested locally
- [x] No secrets or `.env` in the diff
- [ ] CI passes

---

## Additional notes

- **Technical debt:** Full api.ts domain split (core, workflows, billing, settings, deployments) may be incremental.
