### PR TITLE
Potential fix for code scanning alert no. 159: Full server-side request forgery

### DIFF
--- a/services/sandbox-docker/main.py
+++ b/services/sandbox-docker/main.py
@@ -21,6 +21,9 @@ import httpx
 from fastapi import FastAPI, Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, Field
+import ipaddress
+import socket
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -72,11 +75,48 @@ def _run_sync(cmd: list[str], cwd: str | None = None, timeout: int = 120) -> tup
         return -1, "", str(e)
 
 
+def _is_public_ip(ip_str: str) -> bool:
+    """
+    Return True if the given IP address is globally reachable (not private, loopback, etc.).
+    """
+    try:
+        ip_obj = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return False
+    if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local or ip_obj.is_multicast:
+        return False
+    if getattr(ip_obj, "is_reserved", False) or getattr(ip_obj, "is_unspecified", False):
+        return False
+    return True
+
+
+def _validate_tarball_url(tarball_url: str) -> None:
+    """
+    Validate that the tarball URL uses http/https and resolves only to public IP addresses.
+    Raises HTTPException(400) if the URL is not acceptable.
+    """
+    parsed = urlparse(tarball_url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        raise HTTPException(status_code=400, detail="tarball_url must be an http(s) URL with a hostname")
+    hostname = parsed.hostname
+    try:
+        addr_info = socket.getaddrinfo(hostname, parsed.port or 80, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        raise HTTPException(status_code=400, detail="tarball_url host could not be resolved")
+    ips = {ai[4][0] for ai in addr_info if ai and ai[4]}
+    if not ips:
+        raise HTTPException(status_code=400, detail="tarball_url host has no IP addresses")
+    for ip in ips:
+        if not _is_public_ip(ip):
+            raise HTTPException(status_code=400, detail="tarball_url must not point to private or loopback addresses")
+
+
 async def _create_sandbox_container(tarball_url: str, timeout_minutes: int, port: int) -> tuple[str, int]:
     sandbox_id = f"sandbox-{uuid.uuid4().hex[:12]}"
     extract_dir = WORK_DIR / sandbox_id
     extract_dir.mkdir(parents=True, exist_ok=True)
     try:
+        _validate_tarball_url(tarball_url)
         tarball_path = extract_dir / "project.tar.gz"
         async with httpx.AsyncClient(timeout=60) as client:
             r = await client.get(tarball_url)


### PR DESCRIPTION
Potential fix for [https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/159](https://github.com/Hyperkit-Labs/hyperagent/security/code-scanning/159)

In general, to fix full SSRF you must not use raw user input as a complete URL. Instead, constrain where the application is allowed to connect. Typical patterns are: (1) allow‑list a small set of trusted base URLs and let the user control only a limited path/query portion; or (2) validate that the resolved destination is not a private or loopback address, and only then send the request, optionally pinning to the verified IP. For this service, the best minimal change is to validate `tarball_url` before calling `httpx`, ensuring it is an HTTP(S) URL pointing to a non‑private, non‑loopback host.

Concretely, we can:  
1. Parse `tarball_url` using `urllib.parse.urlparse`.  
2. Enforce that the scheme is `http` or `https`, and that a hostname is present.  
3. Resolve the hostname using `socket.getaddrinfo` and ensure that every returned address is public (no loopback, link‑local, or RFC1918 private ranges, and no IPv6 loopback or ULA).  
4. Reject the request with a 400 `HTTPException` if any check fails.  
5. Only if validation passes, call `client.get(tarball_url)` as before.

To implement this without changing external behavior, we’ll add a small helper function (e.g. `_is_public_ip` and `_validate_tarball_url`) above `_create_sandbox_container` in `services/sandbox-docker/main.py`, and add the necessary imports (`urllib.parse` and `ipaddress` and `socket`). Then we’ll call `_validate_tarball_url(tarball_url)` near the top of `_create_sandbox_container` before making the HTTP request. The rest of the workflow (downloading, extracting, running containers) stays unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
