### PR TITLE
infra/docker, packages/backend-middleware, docs: Coolify api-gateway pnpm workspace build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -401,10 +401,11 @@ coverage.xml
 *.lcov
 .coveragerc
 
-# Test results
+# Test results (do not commit - CI/local only)
 test-results/
 test-results.xml
 playwright-report/
+**/playwright-report/
 
 # Dogfood QA output (reports, screenshots, videos). Opt-in to commit specific reports.
 dogfood-output/

--- a/docs/coolify-deployment-guide.md
+++ b/docs/coolify-deployment-guide.md
@@ -22,7 +22,7 @@ Set **Base Directory** per app/service in the monorepo:
 | App/Service | Base Directory |
 |-------------|----------------|
 | Studio | `apps/studio` |
-| API Gateway | `apps/api-gateway` or repo root (see Dockerfile) |
+| API Gateway | **Repo root** (compose / `Dockerfile.api-gateway` uses pnpm + `workspace:*`; do not set base dir to `apps/api-gateway` for the gateway image) |
 | Orchestrator | `.` (repo root) |
 | Full stack (Compose) | `.` (repo root) |
 

--- a/infra/docker/Dockerfile.api-gateway
+++ b/infra/docker/Dockerfile.api-gateway
@@ -1,8 +1,14 @@
+# Build from repo root so workspace:* deps (e.g. @hyperagent/backend-middleware) resolve.
+# Context: repo root (.)
+# npm cannot install workspace: protocol — use pnpm like other Node services in this stack.
 FROM node:20-alpine
+RUN corepack enable && corepack prepare pnpm@10.20.0 --activate
 WORKDIR /app
-COPY apps/api-gateway/package.json ./
-RUN npm install
-COPY apps/api-gateway .
-RUN npm run build
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages ./packages
+COPY apps/api-gateway ./apps/api-gateway
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter hyperagent-api-gateway... build
+WORKDIR /app/apps/api-gateway
 EXPOSE 4000
 CMD ["node", "build/index.js"]

--- a/packages/backend-middleware/package.json
+++ b/packages/backend-middleware/package.json
@@ -9,7 +9,10 @@
     "build": "tsc",
     "dev": "tsx watch src/index.ts"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/core": "^1.25.0"
+  },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "express": "^4.18.2",
@@ -17,9 +20,5 @@
   },
   "peerDependencies": {
     "express": "^4.18.0"
-  },
-  "optionalDependencies": {
-    "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/propagator-w3c-tracecontext": "^1.25.0"
   }
 }

--- a/packages/backend-middleware/src/otel.ts
+++ b/packages/backend-middleware/src/otel.ts
@@ -38,7 +38,7 @@ export function otelRequestSpanMiddleware(req: Request, res: Response, next: Nex
   if (!OTEL_ENABLED) return next();
   try {
     const api = require("@opentelemetry/api");
-    const { W3CTraceContextPropagator } = require("@opentelemetry/propagator-w3c-tracecontext");
+    const { W3CTraceContextPropagator } = require("@opentelemetry/core");
     const propagator = new W3CTraceContextPropagator();
     const carrier: Record<string, string> = {};
     if (req.headers["traceparent"]) carrier.traceparent = req.headers["traceparent"] as string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.22.1
+      express-rate-limit:
+        specifier: ^8.3.1
+        version: 8.3.1(express@4.22.1)
       http-proxy-middleware:
         specifier: ^3.0.5
         version: 3.0.5
@@ -282,6 +285,13 @@ importers:
         version: 5.9.3
 
   packages/backend-middleware:
+    dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
+      '@opentelemetry/core':
+        specifier: ^1.25.0
+        version: 1.30.1(@opentelemetry/api@1.9.0)
     devDependencies:
       '@types/express':
         specifier: ^4.17.21
@@ -292,10 +302,6 @@ importers:
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
-    optionalDependencies:
-      '@opentelemetry/api':
-        specifier: ^1.9.0
-        version: 1.9.0
 
   packages/config: {}
 
@@ -2120,6 +2126,16 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@1.30.1':
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
 
   '@openzeppelin/wizard@0.10.7':
     resolution: {integrity: sha512-IN9FMYP0ViVMrt8KsxILT5MjjLIHuzRMIWprmMxnAo/xw6OTMA3uibP44YdW+tUbMXUg4sA5syL0RVZoMKLE4A==}
@@ -5722,8 +5738,8 @@ packages:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  express-rate-limit@8.3.0:
-    resolution: {integrity: sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==}
+  express-rate-limit@8.3.1:
+    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -9594,7 +9610,7 @@ snapshots:
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
       viem: 2.39.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.3(@types/react@19.2.13)(immer@11.1.3)(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
@@ -9618,7 +9634,7 @@ snapshots:
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
       viem: 2.39.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
       zustand: 5.0.3(@types/react@19.2.13)(immer@11.1.3)(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
@@ -9758,7 +9774,7 @@ snapshots:
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
       viem: 2.39.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.3(@types/react@19.2.13)(immer@11.1.3)(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
@@ -9778,7 +9794,7 @@ snapshots:
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
       viem: 2.39.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
       zustand: 5.0.3(@types/react@19.2.13)(immer@11.1.3)(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
@@ -10987,7 +11003,7 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1
-      express-rate-limit: 8.3.0(express@5.2.1)
+      express-rate-limit: 8.3.1(express@5.2.1)
       hono: 4.12.5
       jose: 6.1.3
       json-schema-typed: 8.0.2
@@ -11111,6 +11127,13 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/semantic-conventions@1.28.0': {}
 
   '@openzeppelin/wizard@0.10.7':
     dependencies:
@@ -17254,7 +17277,12 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
-  express-rate-limit@8.3.0(express@5.2.1):
+  express-rate-limit@8.3.1(express@4.22.1):
+    dependencies:
+      express: 4.22.1
+      ip-address: 10.1.0
+
+  express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
       express: 5.2.1
       ip-address: 10.1.0
@@ -19094,7 +19122,7 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.9(typescript@5.9.3)(zod@4.3.6):
+  ox@0.6.9(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.9.7


### PR DESCRIPTION
## Context / Description

Fixes Coolify/docker-compose **api-gateway** image build failure: `npm install` does not support `workspace:*` (EUNSUPPORTEDPROTOCOL). The Dockerfile now uses **pnpm** from repo root like other Node services.

Replaces non-published `@opentelemetry/propagator-w3c-tracecontext` with `@opentelemetry/core` (W3C propagator) and updates lockfile so `pnpm install --frozen-lockfile` succeeds in Docker.

## Related issues / tickets

- Related: deployment log `deployment-ggww8gc0s00gk0k8w8gsos00-all-logs-2026-03-18` (api-gateway build)

## Type of change

- [x] Bug fix
- [x] Chore (infra, tooling, config)
- [x] Documentation (docs, README, ADRs)

## Scope / affected paths

- `infra/docker/Dockerfile.api-gateway` — pnpm monorepo build
- `packages/backend-middleware` — OTEL dependency fix, `src/otel.ts`
- `pnpm-lock.yaml`
- `docs/coolify-deployment-guide.md` — gateway base directory note
- `.gitignore` — artifact excludes

## How to test

1. `pnpm install --frozen-lockfile`
2. `pnpm --filter hyperagent-api-gateway... build`
3. `docker compose --project-directory . -f infra/docker/docker-compose.yml build api-gateway` (optional)

## CI / local validation

- PASS: `pnpm install --frozen-lockfile`, `pnpm --filter hyperagent-api-gateway... build`
- FAIL (pre-existing on branch; PR workflow uses `continue-on-error: true` for studio typecheck): `pnpm --filter hyperagent-studio run typecheck` — Jest globals in `__tests__`, `lib/session-store.ts` strict DOM typings

## Rollout / risks

- Low risk: aligns gateway image with existing agent-runtime/deploy Docker pattern
- Verify Coolify full-stack build after merge

## Deferred follow-ups

- Restore `hyperagent-studio` `typecheck` to green without `continue-on-error` masking (separate PR)


Made with [Cursor](https://cursor.com)