### PR TITLE
services/orchestrator: fix BYOK auth fallback

### DIFF
--- a/services/orchestrator/api/common.py
+++ b/services/orchestrator/api/common.py
@@ -6,6 +6,8 @@ import json
 import logging
 import os
 import re
+import time
+from base64 import urlsafe_b64decode
 from typing import Any
 
 from fastapi import HTTPException, Request
@@ -127,12 +129,13 @@ def _create_agent_session_jwt_if_configured(
 def get_caller_id(request: Request) -> str | None:
     """Extract authenticated user id from gateway-injected header.
     When IDENTITY_HMAC_SECRET is set, verifies the x-user-id-sig HMAC.
-    Rejects spoofed headers in production."""
+    Rejects spoofed headers in production.
+    Falls back to validated Authorization bearer sub only when X-User-Id is absent."""
     user_id = (
         request.headers.get("X-User-Id") or request.headers.get("x-user-id") or ""
     ).strip() or None
     if not user_id:
-        return None
+        return _get_user_id_from_bearer(request)
     if _IDENTITY_HMAC_SECRET:
         sig = (request.headers.get("x-user-id-sig") or "").strip()
         if not _verify_user_id_hmac(user_id, sig):
@@ -143,6 +146,59 @@ def get_caller_id(request: Request) -> str | None:
             )
             return None
     return user_id
+
+
+def _get_user_id_from_bearer(request: Request) -> str | None:
+    """Resolve wallet_users.id from gateway JWT sub when request bypasses gateway header injection."""
+    secret = os.environ.get("AUTH_JWT_SECRET", "").strip()
+    if not secret:
+        return None
+    auth = (
+        request.headers.get("authorization") or request.headers.get("Authorization") or ""
+    ).strip()
+    if not auth.lower().startswith("bearer "):
+        return None
+    token = auth[7:].strip()
+    if not token:
+        return None
+    payload = _verify_gateway_jwt_hs256(token, secret)
+    if payload is None:
+        return None
+    sub = payload.get("sub")
+    if isinstance(sub, str) and sub.strip():
+        return sub.strip()
+    return None
+
+
+def _b64url_decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return urlsafe_b64decode((value + padding).encode())
+
+
+def _verify_gateway_jwt_hs256(token: str, secret: str) -> dict[str, Any] | None:
+    """Verify compact JWT signature (HS256) and return payload dict."""
+    try:
+        parts = token.split(".")
+        if len(parts) != 3:
+            return None
+        h_b64, p_b64, s_b64 = parts
+        header = json.loads(_b64url_decode(h_b64))
+        if not isinstance(header, dict) or header.get("alg") != "HS256":
+            return None
+        signing_input = f"{h_b64}.{p_b64}".encode()
+        expected = hmac.new(secret.encode(), signing_input, hashlib.sha256).digest()
+        got = _b64url_decode(s_b64)
+        if not hmac.compare_digest(got, expected):
+            return None
+        payload = json.loads(_b64url_decode(p_b64))
+        if not isinstance(payload, dict):
+            return None
+        exp = payload.get("exp")
+        if isinstance(exp, (int, float)) and time.time() >= float(exp):
+            return None
+        return payload
+    except Exception:
+        return None
 
 
 def _run_status_for_store(status: str) -> str:

--- a/services/orchestrator/api/runs_registry.py
+++ b/services/orchestrator/api/runs_registry.py
@@ -599,6 +599,14 @@ def _require_user_id_for_byok(x_user_id: str | None) -> None:
         )
 
 
+def _resolve_byok_user_id(request: Request, x_user_id: str | None) -> str | None:
+    from .common import get_caller_id
+
+    if x_user_id and x_user_id.strip():
+        return x_user_id.strip()
+    return get_caller_id(request)
+
+
 def _trace_llm_keys(
     request: Request,
     method: str,
@@ -637,22 +645,23 @@ async def get_llm_keys(
     import llm_keys_supabase
     from llm_keys_store import get_configured_providers
 
-    _trace_llm_keys(request, "GET", x_user_id, x_workspace_id, "request_received")
+    user_id = _resolve_byok_user_id(request, x_user_id)
+    _trace_llm_keys(request, "GET", user_id, x_workspace_id, "request_received")
     try:
-        _require_user_id_for_byok(x_user_id)
+        _require_user_id_for_byok(user_id)
     except HTTPException:
         _trace_llm_keys(
-            request, "GET", x_user_id, x_workspace_id, "401_missing_x_user_id"
+            request, "GET", user_id, x_workspace_id, "401_missing_x_user_id"
         )
         raise
     wid = x_workspace_id or DEFAULT_WORKSPACE
-    if x_user_id and llm_keys_supabase._is_configured():
+    if user_id and llm_keys_supabase._is_configured():
         from .common import _log_byok_event
 
         def _sync_byok_providers() -> list[str]:
-            db.ensure_wallet_user_profile(x_user_id)
-            _log_byok_event("byok_access", x_user_id, "get_configured_providers")
-            return llm_keys_supabase.get_configured_providers(x_user_id)
+            db.ensure_wallet_user_profile(user_id)
+            _log_byok_event("byok_access", user_id, "get_configured_providers")
+            return llm_keys_supabase.get_configured_providers(user_id)
 
         try:
             providers = await asyncio.wait_for(
@@ -660,7 +669,7 @@ async def get_llm_keys(
                 timeout=BYOK_DB_TIMEOUT_SEC,
             )
         except TimeoutError:
-            _trace_llm_keys(request, "GET", x_user_id, x_workspace_id, "timeout")
+            _trace_llm_keys(request, "GET", user_id, x_workspace_id, "timeout")
             raise HTTPException(
                 status_code=504,
                 detail=(
@@ -670,7 +679,7 @@ async def get_llm_keys(
         _trace_llm_keys(
             request,
             "GET",
-            x_user_id,
+            user_id,
             x_workspace_id,
             "success",
             provider_count=len(providers),
@@ -682,7 +691,7 @@ async def get_llm_keys(
     _trace_llm_keys(
         request,
         "GET",
-        x_user_id,
+        user_id,
         x_workspace_id,
         "success",
         provider_count=len(providers),
@@ -701,38 +710,39 @@ def post_llm_keys(
     import llm_keys_supabase
     from llm_keys_store import set_keys
 
-    _trace_llm_keys(request, "POST", x_user_id, x_workspace_id, "request_received")
+    user_id = _resolve_byok_user_id(request, x_user_id)
+    _trace_llm_keys(request, "POST", user_id, x_workspace_id, "request_received")
     try:
-        _require_user_id_for_byok(x_user_id)
+        _require_user_id_for_byok(user_id)
     except HTTPException:
         _trace_llm_keys(
-            request, "POST", x_user_id, x_workspace_id, "401_missing_x_user_id"
+            request, "POST", user_id, x_workspace_id, "401_missing_x_user_id"
         )
         raise
     if os.environ.get("ENV") == "production" and not (
         os.environ.get("LLM_KEY_ENCRYPTION_KEY")
         or os.environ.get("LLM_KEY_KMS_KEY_ARN")
     ):
-        if x_user_id and (body.keys or {}):
+        if user_id and (body.keys or {}):
             _trace_llm_keys(
-                request, "POST", x_user_id, x_workspace_id, "503_missing_encryption_key"
+                request, "POST", user_id, x_workspace_id, "503_missing_encryption_key"
             )
             raise HTTPException(
                 status_code=503,
                 detail="BYOK requires LLM_KEY_ENCRYPTION_KEY or LLM_KEY_KMS_KEY_ARN in production",
             )
     wid = x_workspace_id or DEFAULT_WORKSPACE
-    if x_user_id and llm_keys_supabase._is_configured():
+    if user_id and llm_keys_supabase._is_configured():
         from .common import _log_byok_event
 
-        db.ensure_wallet_user_profile(x_user_id)
-        _log_byok_event("byok_access", x_user_id, "set_keys")
-        providers = llm_keys_supabase.set_keys_for_user(x_user_id, body.keys or {})
+        db.ensure_wallet_user_profile(user_id)
+        _log_byok_event("byok_access", user_id, "set_keys")
+        providers = llm_keys_supabase.set_keys_for_user(user_id, body.keys or {})
         if body.keys and not providers:
             _trace_llm_keys(
                 request,
                 "POST",
-                x_user_id,
+                user_id,
                 x_workspace_id,
                 "error_storage",
                 provider_count=0,
@@ -744,7 +754,7 @@ def post_llm_keys(
         _trace_llm_keys(
             request,
             "POST",
-            x_user_id,
+            user_id,
             x_workspace_id,
             "success",
             provider_count=len(providers),
@@ -759,7 +769,7 @@ def post_llm_keys(
     _trace_llm_keys(
         request,
         "POST",
-        x_user_id,
+        user_id,
         x_workspace_id,
         "success",
         provider_count=len(providers),
@@ -777,29 +787,31 @@ def delete_llm_keys(
     import llm_keys_supabase
     from llm_keys_store import delete_keys
 
-    _trace_llm_keys(request, "DELETE", x_user_id, x_workspace_id, "request_received")
+    user_id = _resolve_byok_user_id(request, x_user_id)
+    _trace_llm_keys(request, "DELETE", user_id, x_workspace_id, "request_received")
     try:
-        _require_user_id_for_byok(x_user_id)
+        _require_user_id_for_byok(user_id)
     except HTTPException:
         _trace_llm_keys(
-            request, "DELETE", x_user_id, x_workspace_id, "401_missing_x_user_id"
+            request, "DELETE", user_id, x_workspace_id, "401_missing_x_user_id"
         )
         raise
     wid = x_workspace_id or DEFAULT_WORKSPACE
-    if x_user_id and llm_keys_supabase._is_configured():
+    if user_id and llm_keys_supabase._is_configured():
         from .common import _log_byok_event
 
-        _log_byok_event("byok_access", x_user_id, "delete_keys")
-        llm_keys_supabase.delete_keys_for_user(x_user_id)
-        _trace_llm_keys(request, "DELETE", x_user_id, x_workspace_id, "success")
+        _log_byok_event("byok_access", user_id, "delete_keys")
+        llm_keys_supabase.delete_keys_for_user(user_id)
+        _trace_llm_keys(request, "DELETE", user_id, x_workspace_id, "success")
         return {"configured_providers": []}
     delete_keys(wid)
-    _trace_llm_keys(request, "DELETE", x_user_id, x_workspace_id, "success")
+    _trace_llm_keys(request, "DELETE", user_id, x_workspace_id, "success")
     return {"configured_providers": []}
 
 
 @llm_keys_router.post("/llm-keys/validate")
 async def validate_llm_key(
+    request: Request,
     body: LLMKeyValidateBody,
     x_workspace_id: str | None = Header(None, alias="X-Workspace-Id"),
     x_user_id: str | None = Header(None, alias="X-User-Id"),
@@ -808,13 +820,14 @@ async def validate_llm_key(
     import llm_keys_supabase
     from llm_keys_store import get_keys_for_pipeline
 
+    user_id = _resolve_byok_user_id(request, x_user_id)
     api_key = (body.api_key or "").strip()
     if not api_key:
-        _require_user_id_for_byok(x_user_id)
+        _require_user_id_for_byok(user_id)
         wid = x_workspace_id or DEFAULT_WORKSPACE
         stored: dict[str, str] = {}
-        if x_user_id and llm_keys_supabase._is_configured():
-            stored = llm_keys_supabase.get_keys_for_user(x_user_id) or {}
+        if user_id and llm_keys_supabase._is_configured():
+            stored = llm_keys_supabase.get_keys_for_user(user_id) or {}
         else:
             stored = get_keys_for_pipeline(wid) or {}
         api_key = (stored or {}).get(body.provider.strip().lower(), "")

--- a/services/orchestrator/tests/unit/test_connectivity_hardening.py
+++ b/services/orchestrator/tests/unit/test_connectivity_hardening.py
@@ -13,7 +13,12 @@ Covers:
 from __future__ import annotations
 
 import importlib
+import importlib.util
 import os
+import sys
+import types
+from base64 import urlsafe_b64encode
+from pathlib import Path
 
 import pytest
 
@@ -35,10 +40,7 @@ def test_redact_error_for_logs_masks_secrets() -> None:
     from api.common import redact_error_for_logs
 
     assert redact_error_for_logs("ok") == "ok"
-    assert (
-        redact_error_for_logs("Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
-        == "[redacted]"
-    )
+    assert redact_error_for_logs("Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9") == "[redacted]"
 
 
 def test_get_keys_for_run_swallows_exception_without_leaking(
@@ -51,13 +53,91 @@ def test_get_keys_for_run_swallows_exception_without_leaking(
         raise RuntimeError("DB error: api_key=sk-supersecretkey123456")
 
     monkeypatch.setattr("llm_keys_supabase._is_configured", lambda: True, raising=False)
-    monkeypatch.setattr(
-        "llm_keys_supabase.get_keys_for_user", _bad_get_user, raising=False
-    )
+    monkeypatch.setattr("llm_keys_supabase.get_keys_for_user", _bad_get_user, raising=False)
 
     # Must return empty dict, not raise
     result = common._get_keys_for_run("user-123", "ws-abc")
     assert result == {}
+
+
+def test_get_caller_id_falls_back_to_bearer_sub_when_header_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    common = _load_common_module()
+
+    secret = "test-secret"
+    token = _mint_hs256_jwt({"sub": "550e8400-e29b-41d4-a716-446655440000"}, secret)
+    monkeypatch.setenv("AUTH_JWT_SECRET", secret)
+    monkeypatch.setattr(common, "_IDENTITY_HMAC_SECRET", "", raising=False)
+
+    class _Req:
+        def __init__(self) -> None:
+            self.headers = {"authorization": f"Bearer {token}"}
+            self.url = type("Url", (), {"path": "/api/v1/workspaces/current/llm-keys"})()
+
+    assert common.get_caller_id(_Req()) == "550e8400-e29b-41d4-a716-446655440000"
+
+
+def test_get_caller_id_does_not_use_bearer_when_spoofed_header_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    common = _load_common_module()
+
+    secret = "test-secret"
+    token = _mint_hs256_jwt({"sub": "550e8400-e29b-41d4-a716-446655440000"}, secret)
+    monkeypatch.setenv("AUTH_JWT_SECRET", secret)
+    monkeypatch.setattr(common, "_IDENTITY_HMAC_SECRET", "hmac-secret", raising=False)
+
+    class _Req:
+        def __init__(self) -> None:
+            self.headers = {
+                "X-User-Id": "spoofed-user-id",
+                "authorization": f"Bearer {token}",
+            }
+            self.url = type("Url", (), {"path": "/api/v1/workspaces/current/llm-keys"})()
+
+    assert common.get_caller_id(_Req()) is None
+
+
+def _mint_hs256_jwt(payload: dict[str, str], secret: str) -> str:
+    import hashlib
+    import hmac
+    import json
+
+    def _b64(data: bytes) -> str:
+        return urlsafe_b64encode(data).decode().rstrip("=")
+
+    header = {"alg": "HS256", "typ": "JWT"}
+    h_b64 = _b64(json.dumps(header, separators=(",", ":")).encode())
+    p_b64 = _b64(json.dumps(payload, separators=(",", ":")).encode())
+    signing_input = f"{h_b64}.{p_b64}".encode()
+    sig = hmac.new(secret.encode(), signing_input, hashlib.sha256).digest()
+    s_b64 = _b64(sig)
+    return f"{h_b64}.{p_b64}.{s_b64}"
+
+
+def _load_common_module():
+    common_path = Path(__file__).resolve().parents[2] / "api" / "common.py"
+    spec = importlib.util.spec_from_file_location("orchestrator_common_test", common_path)
+    assert spec and spec.loader
+    if "fastapi" not in sys.modules:
+        fastapi_stub = types.ModuleType("fastapi")
+
+        class HTTPException(Exception):
+            def __init__(self, status_code: int, detail: str) -> None:
+                super().__init__(detail)
+                self.status_code = status_code
+                self.detail = detail
+
+        class Request:  # pragma: no cover - minimal stub for module import
+            pass
+
+        fastapi_stub.HTTPException = HTTPException
+        fastapi_stub.Request = Request
+        sys.modules["fastapi"] = fastapi_stub
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 # ---------------------------------------------------------------------------
@@ -94,9 +174,7 @@ def test_audit_mandatory_false_disables_service_block() -> None:
             "category": "service",
         }
         blocked = aa._finding_blocks_deploy(finding, [finding])
-        assert (
-            blocked is False
-        ), "AUDIT_MANDATORY=false should not block on service unavailability"
+        assert blocked is False, "AUDIT_MANDATORY=false should not block on service unavailability"
     finally:
         os.environ.pop("AUDIT_MANDATORY", None)
         importlib.reload(aa)
@@ -116,9 +194,7 @@ def test_audit_mandatory_true_blocks_on_service_unavailable() -> None:
             "category": "service",
         }
         blocked = aa._finding_blocks_deploy(finding, [finding])
-        assert (
-            blocked is True
-        ), "AUDIT_MANDATORY=true must block on service unavailability"
+        assert blocked is True, "AUDIT_MANDATORY=true must block on service unavailability"
     finally:
         os.environ.pop("AUDIT_MANDATORY", None)
         importlib.reload(aa)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"b09dfe10-5498-47aa-a098-0034355927cf","source":"chat","resourceId":"eb0c53eb-20ef-4c93-8e7e-f8a1f494e912","workflowId":"558b03b6-5fbd-429e-86f9-dc5ee5947321","codeChangeId":"558b03b6-5fbd-429e-86f9-dc5ee5947321","sourceType":"chat"} -->
# Pull Request

---

## Title / Naming convention

Use a **clear, concise title** in the format enforced by CI:

- **Required format**: `directory or scope: short description`
- **Examples**: `services/orchestrator: add provider resolver`, `docs/planning: update master index`, `apps/hyperagent-web, libs/sdk-ts: fix login flow`
- **Avoid**: Titles that look like generic Conventional Commits only (for example `feat: add feature`). Use the directory-prefix format so reviewers and CI can validate scope.

---

## Context / Description

BYOK reads and writes were failing with 401 when requests reached orchestrator without `X-User-Id`, even when a valid gateway JWT was present in `Authorization`.

This PR adds validation-aware user resolution for llm-keys routes so orchestrator can derive `wallet_users.id` from a verified bearer token only when `X-User-Id` is absent, while preserving spoofed-header protections.

---

## Related issues / tickets

Link to relevant GitHub issues or external tickets so reviewers have full context.

- **Closes**
- **Related**

---

## Type of change

Classify this PR (check one or more as applicable):

- [ ] **Feature** (Phase 1 / 2 / 3 — align with issue phase labels)
- [x] **Bug fix**
- [ ] **Documentation** (docs, README, ADRs)
- [ ] **Chore** (infra, tooling, config)
- [ ] **Refactor** (no new behavior)
- [ ] **Other**

---

## How to test

Steps for reviewers (or CI) to verify the changes:

1. Authenticate via wallet bootstrap and obtain a valid bearer token.
2. Call `/api/v1/workspaces/current/llm-keys` without `X-User-Id` but with `Authorization: Bearer <token>`; verify llm-keys no longer fail with `401_missing_x_user_id` when BYOK is configured.
3. Send a spoofed `X-User-Id` with invalid/missing signature and a bearer token; verify caller identity does not fall back to bearer when spoofed header is present.

**Special setup / config:**
- `AUTH_JWT_SECRET` must be set for bearer fallback verification.

---

## Screenshots / demos

For **UI or behavior changes**, add screenshots or a short GIF to illustrate.

---

## Author checklist (before requesting review)

- [x] Code follows the project's style guidelines (see `.cursor/rules/rules.mdc`)
- [x] Unit tests added or updated and coverage is acceptable (target 80%+ where applicable)
- [ ] Documentation (code comments, README, ADRs) updated as needed
- [x] Changes tested locally (and steps captured in "How to test" above)
- [x] No secrets or `.env` in the diff
- [ ] CODEOWNERS review expected for touched paths
- [ ] CI passes (including PR title/format and any template checks)

---

## Additional notes

Optional but helpful for reviewers:

- **Performance**: No material impact; fallback logic runs only when `X-User-Id` is absent.
- **Technical debt**: None.
- **Breaking changes**: None.
- **Other**: Added unit coverage for bearer fallback and spoofed-header precedence in `services/orchestrator/tests/unit/test_connectivity_hardening.py`.

---

PR by Bits - [View session in Datadog](https://us5.datadoghq.com/code/eb0c53eb-20ef-4c93-8e7e-f8a1f494e912)

Comment @datadog to request changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperkit-labs/hyperagent/pull/436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
